### PR TITLE
Tapegun idle hooks, orch upgrade health fix

### DIFF
--- a/host/provision.sh
+++ b/host/provision.sh
@@ -904,6 +904,8 @@ done)
         fi
       fi
 
+      # Reset any failed state (service may have crashed before cloud-init wrote config)
+      systemctl reset-failed boxcutter-orchestrator 2>/dev/null || true
       systemctl restart boxcutter-orchestrator || echo "WARNING: boxcutter-orchestrator restart failed"
 
       # Verify the service is running

--- a/plugins/tapegun-guest/hooks/hooks.json
+++ b/plugins/tapegun-guest/hooks/hooks.json
@@ -17,7 +17,40 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/report-status.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/report-status.sh idle"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/report-status.sh idle"
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/report-status.sh error"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/report-status.sh working"
           }
         ]
       }

--- a/plugins/tapegun-guest/hooks/report-status.sh
+++ b/plugins/tapegun-guest/hooks/report-status.sh
@@ -1,33 +1,55 @@
 #!/bin/bash
-# Report Claude Code status to tapegun after each response.
-# Runs as a Stop hook — fires every time Claude finishes a turn.
-# Posts the last assistant message to the metadata service for
-# host-side monitoring via tapegun activity.
+# Report Claude Code agent status to tapegun metadata service.
+# Called by Stop, SubagentStop, StopFailure, and UserPromptSubmit hooks.
+#
+# Usage: report-status.sh <idle|working|error>
+#
+# Stop/SubagentStop  → "idle"    (agent finished a turn)
+# UserPromptSubmit   → "working" (user submitted a new prompt)
+# StopFailure        → "error"   (turn ended due to API error)
 
 METADATA="http://169.254.169.254"
 STATUS_FILE="/home/dev/.tapegun/status.json"
+STATUS="${1:-idle}"
 
 # Read hook input from stdin
 input=$(cat)
 
-# Extract last_assistant_message
-message=$(echo "$input" | jq -r '.last_assistant_message // empty' 2>/dev/null)
-[ -z "$message" ] && exit 0
+# Guard against infinite loops — if stop_hook_active is true, the hook
+# itself triggered this invocation. Skip to avoid recursion.
+stop_active=$(echo "$input" | jq -r '.stop_hook_active // false' 2>/dev/null)
+if [ "$stop_active" = "true" ]; then
+    exit 0
+fi
 
-# Truncate to last 500 chars to keep payload small
+# Extract context from hook payload
+session_id=$(echo "$input" | jq -r '.session_id // empty' 2>/dev/null)
+message=$(echo "$input" | jq -r '.last_assistant_message // empty' 2>/dev/null)
+
+# Truncate message to last 500 chars
 if [ ${#message} -gt 500 ]; then
     message="...${message: -500}"
 fi
 
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
 # Write local status file
 mkdir -p /home/dev/.tapegun
-jq -n --arg msg "$message" --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-    '{last_response: $msg, timestamp: $ts}' > "$STATUS_FILE" 2>/dev/null
+jq -n --arg status "$STATUS" \
+       --arg msg "$message" \
+       --arg ts "$TIMESTAMP" \
+       --arg sid "$session_id" \
+    '{status: $status, last_response: $msg, timestamp: $ts, session_id: $sid}' \
+    > "$STATUS_FILE" 2>/dev/null
 
-# Post to metadata service (best-effort, don't block Claude)
+# Post to metadata service (best-effort, non-blocking)
 curl -sf -X POST "$METADATA/tapegun/activity" \
     -H "Content-Type: application/json" \
-    -d "$(jq -n --arg msg "$message" '{status: "claude-code", summary: $msg}')" \
+    -d "$(jq -n --arg status "$STATUS" \
+                --arg msg "$message" \
+                --arg ts "$TIMESTAMP" \
+                --arg sid "$session_id" \
+        '{status: $status, summary: $msg, timestamp: $ts, session_id: $sid}')" \
     --max-time 2 >/dev/null 2>&1 &
 
 exit 0


### PR DESCRIPTION
## Changes

- **Issue #34**: Tapegun guest plugin Stop hook for reliable idle notifications. Posts status to metadata service on turn completion.
- **Issue #28**: Verify tapegun runs from tools.img (already done in v0.22.0, this adds the Stop/StopFailure hooks).
- **Issue #30**: Orchestrator upgrade fix — checks PID/IsRunning before polling health. Dead process triggers immediate cleanup + retry with console log diagnostics. Also fixes cloud-init systemctl reset-failed issue.

## Test plan

- [ ] Verify Stop hook fires and tapegun activity shows idle/working status
- [ ] Verify orch upgrade detects dead QEMU and retries