### PR TITLE
Fix #89: authenticate gh CLI in token refresh script

### DIFF
--- a/node/golden/gh-token-refresh.sh
+++ b/node/golden/gh-token-refresh.sh
@@ -19,17 +19,9 @@ if [ -z "$token" ]; then
     exit 1
 fi
 
-# Write the token so gh CLI picks it up
-export GH_TOKEN="$token"
-
-# Also persist for non-interactive use
-mkdir -p "$HOME/.config/gh"
-cat > "$HOME/.config/gh/hosts.yml" <<EOF
-github.com:
-    oauth_token: $token
-    user: x-access-token
-    git_protocol: https
-EOF
+# Authenticate the gh CLI so `gh auth status` works and all gh
+# commands (pr create, issue list, etc.) pick up the token.
+echo "$token" | gh auth login --with-token
 
 # Update git credential helper so HTTPS git operations use the fresh token
 git config --global credential.helper '!f() { echo "username=x-access-token"; echo "password='"$token"'"; }; f'


### PR DESCRIPTION
## Summary
- Replace manual `hosts.yml` write with `gh auth login --with-token` in `gh-token-refresh.sh`
- This ensures `gh auth status` shows authenticated after VM boot, and all `gh` commands work correctly
- The manual file write was missing fields the CLI expects, so `gh auth status` didn't recognize the session

## Test plan
- [ ] Boot a new VM and verify `gh auth status` shows authenticated after the timer fires
- [ ] Verify `gh pr list`, `gh issue list` etc. work inside the VM
- [ ] Verify git clone/push over HTTPS still works (credential helper unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)