### PR TITLE
Fix #95: auto-install tapegun-guest plugin before Claude Code launch

### DIFF
--- a/node/golden/config/boxcutter-tapegun
+++ b/node/golden/config/boxcutter-tapegun
@@ -101,6 +101,17 @@ EOSETTINGS
             sleep 0.5
         fi
 
+        # Install tapegun-guest plugin so inbox, stop notifications, and
+        # status reporting hooks are active in the Claude Code session.
+        PLUGIN_DIR="$HOME/.claude/plugins/tapegun-guest"
+        if [ -d "$PLUGIN_DIR" ]; then
+            tmux send-keys -t main "claude plugin install $PLUGIN_DIR 2>/dev/null" Enter
+            sleep 2
+            echo "tapegun: installed tapegun-guest plugin"
+        else
+            echo "tapegun: WARNING: plugin not found at $PLUGIN_DIR"
+        fi
+
         # Start Claude Code
         CLAUDE_CMD="claude"
         [ -n "$CLAUDE_FLAGS" ] && CLAUDE_CMD="$CLAUDE_CMD $CLAUDE_FLAGS"


### PR DESCRIPTION
## Summary
- Run `claude plugin install ~/.claude/plugins/tapegun-guest` in the tmux session after cd'ing to the working directory but before launching Claude Code
- The plugin files were already baked into the golden image by `docker-to-ext4.sh`, but never registered with Claude Code — `claude plugin list` showed no plugins
- Fixes inbox delivery (`tapegun send`), stop notifications, and status reporting hooks

## Test plan
- [ ] Boot a fresh VM, verify `claude plugin list` shows `tapegun-guest`
- [ ] `tapegun send` messages appear in Claude Code session within 30s
- [ ] Stop hook fires when Claude Code session ends (check vmid activity endpoint)
- [ ] Status reporting works on UserPromptSubmit

🤖 Generated with [Claude Code](https://claude.com/claude-code)