### PR TITLE
Fix #88: FC tools.img parity — add tapegun to legacy build path

### DIFF
--- a/node/golden/build.sh
+++ b/node/golden/build.sh
@@ -75,6 +75,12 @@ mkdir -p "${WORK}/mnt/etc/systemd/system/local-fs.target.wants"
 ln -sf /etc/systemd/system/opt-boxcutter-tools.automount \
   "${WORK}/mnt/etc/systemd/system/local-fs.target.wants/opt-boxcutter-tools.automount"
 ln -sf /opt/boxcutter/tools/bin/boxcutter "${WORK}/mnt/usr/local/bin/boxcutter"
+ln -sf /opt/boxcutter/tools/bin/boxcutter-tapegun "${WORK}/mnt/usr/local/bin/boxcutter-tapegun"
+ln -sf /opt/boxcutter/tools/etc/systemd/boxcutter-tapegun.service \
+  "${WORK}/mnt/etc/systemd/system/boxcutter-tapegun.service"
+mkdir -p "${WORK}/mnt/etc/systemd/system/multi-user.target.wants"
+ln -sf /etc/systemd/system/boxcutter-tapegun.service \
+  "${WORK}/mnt/etc/systemd/system/multi-user.target.wants/boxcutter-tapegun.service"
 
 # --- Set hostname from kernel ip= parameter ---
 cat > "${WORK}/mnt/etc/systemd/system/set-hostname.service" << 'SVCEOF'


### PR DESCRIPTION
## Summary

- Add missing tapegun daemon symlink and systemd service to the legacy debootstrap golden image build path (`node/golden/build.sh`)
- The Dockerfile-based build (`docker-to-ext4.sh`) and FC VM config (`writeFirecrackerConfig`) already have full tools.img support — this closes the remaining gap

### What was already in place

| Component | Status | Location |
|-----------|--------|----------|
| FC config attaches tools.img as drive_id "tools" | ✅ Already done | `node/agent/internal/vm/manager.go:1127-1137` |
| Dockerfile golden image: mount units + tapegun | ✅ Already done | `node/golden/Dockerfile:162-177` |
| QEMU rootfs prep: mount units + tapegun | ✅ Already done | `node/agent/internal/vm/qemu.go:268-323` |
| tools.img deployed to nodes | ✅ Already done | `host/provision.sh:292-296` |
| Legacy build.sh: tapegun symlink + service | ❌ **Missing** | `node/golden/build.sh:77` |

### What this PR fixes

The legacy `build.sh` (debootstrap path) had the boxcutter CLI symlink and mount units but was missing:
- `boxcutter-tapegun` binary symlink
- `boxcutter-tapegun.service` systemd unit symlink
- Service enablement in `multi-user.target.wants`

FC VMs built via this path would have tools.img mounted at `/opt/boxcutter/tools` but the tapegun daemon wouldn't run.

## Test plan
- [ ] Build golden image via `boxcutter-ctl golden build` (Dockerfile path) — verify tools.img mounted, tapegun running
- [ ] Build golden image via legacy `build.sh` — verify tapegun service enabled
- [ ] Create FC VM, confirm `/opt/boxcutter/tools` mounted and `systemctl status boxcutter-tapegun` is active

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)