### PR TITLE
Prep #94: team CLI skeleton + YAML parser

### DIFF
--- a/host/cmd/host/main.go
+++ b/host/cmd/host/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/AndrewBudd/boxcutter/host/internal/cluster"
 	"github.com/AndrewBudd/boxcutter/host/internal/oci"
 	"github.com/AndrewBudd/boxcutter/host/internal/qemu"
+	"github.com/AndrewBudd/boxcutter/host/internal/team"
 )
 
 // version is set at build time via -ldflags "-X main.version=..."
@@ -348,6 +349,8 @@ func main() {
 		cliRecover()
 	case "self-update":
 		cliSelfUpdate()
+	case "team":
+		cliTeam()
 	default:
 		fmt.Fprintf(os.Stderr, "Usage: boxcutter-host <command>\n\n")
 		fmt.Fprintf(os.Stderr, "Commands:\n")
@@ -364,6 +367,10 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  remove-node <id>             Remove a node entry (kills QEMU if running)\n")
 		fmt.Fprintf(os.Stderr, "  list-orphans                 Show nodes with 0 VMs (cleanup candidates)\n")
 		fmt.Fprintf(os.Stderr, "  cleanup-nodes                Remove all orphan nodes\n")
+		fmt.Fprintf(os.Stderr, "  team apply -f team.yaml      Create/update team from YAML spec\n")
+		fmt.Fprintf(os.Stderr, "  team destroy -f team.yaml    Destroy all VMs defined in team spec\n")
+		fmt.Fprintf(os.Stderr, "  team list                    List active teams\n")
+		fmt.Fprintf(os.Stderr, "  team status -f team.yaml     Show status of team VMs\n")
 		os.Exit(1)
 	}
 }
@@ -5109,4 +5116,205 @@ func runBootstrap() {
 	}
 
 	log.Printf("Bootstrap complete. State saved to %s", cfg.StatePath)
+}
+
+// cliTeam handles the "team" subcommand family.
+func cliTeam() {
+	if len(os.Args) < 3 {
+		teamUsage()
+	}
+
+	subcmd := os.Args[2]
+	switch subcmd {
+	case "apply":
+		teamApply()
+	case "destroy":
+		teamDestroy()
+	case "list":
+		teamList()
+	case "status":
+		teamStatus()
+	default:
+		teamUsage()
+	}
+}
+
+func teamUsage() {
+	fmt.Fprintf(os.Stderr, "Usage: boxcutter-host team <subcommand>\n\n")
+	fmt.Fprintf(os.Stderr, "Subcommands:\n")
+	fmt.Fprintf(os.Stderr, "  apply   -f team.yaml   Create or update team to match spec\n")
+	fmt.Fprintf(os.Stderr, "  destroy -f team.yaml   Destroy all VMs defined in team spec\n")
+	fmt.Fprintf(os.Stderr, "  list                   List active teams\n")
+	fmt.Fprintf(os.Stderr, "  status  -f team.yaml   Show status of team VMs\n")
+	os.Exit(1)
+}
+
+func teamParseFile() *team.TeamSpec {
+	filePath := ""
+	for i := 3; i < len(os.Args); i++ {
+		if os.Args[i] == "-f" && i+1 < len(os.Args) {
+			filePath = os.Args[i+1]
+			break
+		}
+	}
+	if filePath == "" {
+		fmt.Fprintf(os.Stderr, "Error: -f <file> is required\n")
+		os.Exit(1)
+	}
+	ts, err := team.LoadFile(filePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	return ts
+}
+
+func teamApply() {
+	ts := teamParseFile()
+	agents := ts.Resolve()
+
+	fmt.Printf("Team: %s\n", ts.Metadata.Name)
+	fmt.Printf("Agents: %d definitions → %d VMs\n\n", len(ts.Spec.Agents), len(agents))
+
+	cfg := defaultConfig()
+	state, _ := cluster.Load(cfg.StatePath)
+
+	// Build set of existing VM names from orchestrator
+	existing := make(map[string]bool)
+	orchAddr := ""
+	if state != nil && state.Orchestrator != nil {
+		orchAddr = fmt.Sprintf("http://%s:8801", state.Orchestrator.BridgeIP)
+		client := &http.Client{Timeout: 5 * time.Second}
+		resp, err := client.Get(orchAddr + "/api/vms")
+		if err == nil {
+			var vms []map[string]interface{}
+			json.NewDecoder(resp.Body).Decode(&vms)
+			resp.Body.Close()
+			for _, vm := range vms {
+				if name, ok := vm["name"].(string); ok {
+					existing[name] = true
+				}
+			}
+		}
+	}
+
+	for _, a := range agents {
+		action := "create"
+		if existing[a.VMName] {
+			action = "ok (exists)"
+		}
+		fmt.Printf("  %-8s %s  [%s vcpu=%d ram=%s disk=%s mode=%s]\n",
+			action, a.VMName, a.Type, a.VCPU, a.RAM, a.Disk, a.Mode)
+		if a.Persona != nil && a.Persona.Role != "" {
+			fmt.Printf("           persona: %s\n", a.Persona.Role)
+		}
+		if len(a.Repos) > 0 {
+			fmt.Printf("           repos: %s\n", strings.Join(a.Repos, ", "))
+		}
+		if len(a.Access) > 0 {
+			fmt.Printf("           access: %s\n", strings.Join(a.Access, ", "))
+		}
+	}
+
+	if orchAddr == "" {
+		fmt.Println("\n⚠ Orchestrator not available — dry-run only (no VMs created)")
+	} else {
+		fmt.Println("\n[dry-run] No VMs created yet — reconciliation not implemented")
+	}
+}
+
+func teamDestroy() {
+	ts := teamParseFile()
+	agents := ts.Resolve()
+
+	fmt.Printf("Team: %s\n", ts.Metadata.Name)
+	fmt.Printf("Would destroy %d VMs:\n\n", len(agents))
+
+	for _, a := range agents {
+		fmt.Printf("  destroy  %s\n", a.VMName)
+	}
+
+	fmt.Println("\n[dry-run] No VMs destroyed — reconciliation not implemented")
+}
+
+func teamList() {
+	cfg := defaultConfig()
+	state, err := cluster.Load(cfg.StatePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading state: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Discover teams by scanning VM names for the {team}-{agent}-{N} pattern
+	teams := make(map[string]int)
+	orchAddr := ""
+	if state.Orchestrator != nil {
+		orchAddr = fmt.Sprintf("http://%s:8801", state.Orchestrator.BridgeIP)
+		client := &http.Client{Timeout: 5 * time.Second}
+		resp, err := client.Get(orchAddr + "/api/vms")
+		if err == nil {
+			var vms []map[string]interface{}
+			json.NewDecoder(resp.Body).Decode(&vms)
+			resp.Body.Close()
+			for _, vm := range vms {
+				name, _ := vm["name"].(string)
+				// Heuristic: team VMs are named {team}-{agent}-{N}
+				parts := strings.Split(name, "-")
+				if len(parts) >= 3 {
+					// Last part should be a number (replica index)
+					if _, err := strconv.Atoi(parts[len(parts)-1]); err == nil {
+						teamName := strings.Join(parts[:len(parts)-2], "-")
+						teams[teamName]++
+					}
+				}
+			}
+		}
+	}
+
+	if len(teams) == 0 {
+		fmt.Println("No teams found")
+		return
+	}
+
+	fmt.Printf("%-30s  VMs\n", "TEAM")
+	for name, count := range teams {
+		fmt.Printf("%-30s  %d\n", name, count)
+	}
+}
+
+func teamStatus() {
+	ts := teamParseFile()
+	agents := ts.Resolve()
+
+	cfg := defaultConfig()
+	state, _ := cluster.Load(cfg.StatePath)
+
+	// Query orchestrator for VM status
+	vmStatus := make(map[string]string)
+	if state != nil && state.Orchestrator != nil {
+		orchAddr := fmt.Sprintf("http://%s:8801", state.Orchestrator.BridgeIP)
+		client := &http.Client{Timeout: 5 * time.Second}
+		resp, err := client.Get(orchAddr + "/api/vms")
+		if err == nil {
+			var vms []map[string]interface{}
+			json.NewDecoder(resp.Body).Decode(&vms)
+			resp.Body.Close()
+			for _, vm := range vms {
+				name, _ := vm["name"].(string)
+				status, _ := vm["status"].(string)
+				vmStatus[name] = status
+			}
+		}
+	}
+
+	fmt.Printf("Team: %s\n\n", ts.Metadata.Name)
+	fmt.Printf("%-40s  %-12s  %-6s  %-5s  %s\n", "VM", "STATUS", "TYPE", "VCPU", "RAM")
+	for _, a := range agents {
+		status := "missing"
+		if s, ok := vmStatus[a.VMName]; ok {
+			status = s
+		}
+		fmt.Printf("%-40s  %-12s  %-6s  %-5d  %s\n",
+			a.VMName, status, a.Type, a.VCPU, a.RAM)
+	}
 }

--- a/host/go.mod
+++ b/host/go.mod
@@ -7,5 +7,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	golang.org/x/sync v0.14.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	oras.land/oras-go/v2 v2.6.0 // indirect
 )

--- a/host/go.sum
+++ b/host/go.sum
@@ -6,5 +6,9 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
 golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=
 oras.land/oras-go/v2 v2.6.0/go.mod h1:magiQDfG6H1O9APp+rOsvCPcW1GD2MM7vgnKY0Y+u1o=

--- a/host/internal/team/spec.go
+++ b/host/internal/team/spec.go
@@ -1,0 +1,220 @@
+package team
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TeamSpec is the top-level structure for a team YAML file.
+type TeamSpec struct {
+	APIVersion string   `yaml:"apiVersion"`
+	Kind       string   `yaml:"kind"`
+	Metadata   Metadata `yaml:"metadata"`
+	Spec       Spec     `yaml:"spec"`
+}
+
+type Metadata struct {
+	Name   string            `yaml:"name"`
+	Labels map[string]string `yaml:"labels,omitempty"`
+}
+
+type Spec struct {
+	Defaults *AgentDefaults `yaml:"defaults,omitempty"`
+	Agents   []AgentSpec    `yaml:"agents"`
+}
+
+// AgentDefaults holds shared defaults inherited by all agents.
+// Agent-level values override defaults. List fields (repos, access)
+// are replaced, not merged.
+type AgentDefaults struct {
+	Type       string  `yaml:"type,omitempty"`
+	RAM        string  `yaml:"ram,omitempty"`
+	VCPU       int     `yaml:"vcpu,omitempty"`
+	Disk       string  `yaml:"disk,omitempty"`
+	Mode       string  `yaml:"mode,omitempty"`
+	Repos      []string `yaml:"repos,omitempty"`
+	Authorized bool    `yaml:"authorized,omitempty"`
+	Persona    *Persona `yaml:"persona,omitempty"`
+}
+
+type AgentSpec struct {
+	Name        string   `yaml:"name"`
+	Replicas    int      `yaml:"replicas,omitempty"`
+	RAM         string   `yaml:"ram,omitempty"`
+	VCPU        int      `yaml:"vcpu,omitempty"`
+	Disk        string   `yaml:"disk,omitempty"`
+	Type        string   `yaml:"type,omitempty"`
+	Mode        string   `yaml:"mode,omitempty"`
+	Description string   `yaml:"description,omitempty"`
+	Persona     *Persona `yaml:"persona,omitempty"`
+	Repos       []string `yaml:"repos,omitempty"`
+	Access      []string `yaml:"access,omitempty"`
+	Authorized  *bool    `yaml:"authorized,omitempty"`
+}
+
+type Persona struct {
+	Role         string `yaml:"role,omitempty"`
+	ClaudeMD     string `yaml:"claude_md,omitempty"`
+	Instructions string `yaml:"instructions,omitempty"`
+}
+
+// LoadFile parses a team YAML file from disk.
+func LoadFile(path string) (*TeamSpec, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	return Parse(data)
+}
+
+// Parse parses team YAML bytes.
+func Parse(data []byte) (*TeamSpec, error) {
+	var ts TeamSpec
+	if err := yaml.Unmarshal(data, &ts); err != nil {
+		return nil, fmt.Errorf("parsing YAML: %w", err)
+	}
+	if ts.Kind != "Team" {
+		return nil, fmt.Errorf("expected kind: Team, got %q", ts.Kind)
+	}
+	if ts.Metadata.Name == "" {
+		return nil, fmt.Errorf("metadata.name is required")
+	}
+	if len(ts.Spec.Agents) == 0 {
+		return nil, fmt.Errorf("spec.agents must contain at least one agent")
+	}
+	for i, a := range ts.Spec.Agents {
+		if a.Name == "" {
+			return nil, fmt.Errorf("spec.agents[%d].name is required", i)
+		}
+	}
+	return &ts, nil
+}
+
+// ResolvedAgent is an agent spec with defaults applied and replicas expanded.
+type ResolvedAgent struct {
+	VMName      string
+	AgentName   string
+	ReplicaNum  int
+	Type        string
+	RAM         string
+	VCPU        int
+	Disk        string
+	Mode        string
+	Description string
+	Persona     *Persona
+	Repos       []string
+	Access      []string
+	Authorized  bool
+}
+
+// Resolve applies defaults and expands replicas into concrete VM definitions.
+func (ts *TeamSpec) Resolve() []ResolvedAgent {
+	var out []ResolvedAgent
+	for _, a := range ts.Spec.Agents {
+		replicas := a.Replicas
+		if replicas < 1 {
+			replicas = 1
+		}
+		for i := 1; i <= replicas; i++ {
+			r := ResolvedAgent{
+				VMName:      fmt.Sprintf("%s-%s-%d", ts.Metadata.Name, a.Name, i),
+				AgentName:   a.Name,
+				ReplicaNum:  i,
+				Description: a.Description,
+			}
+
+			// Apply defaults, then agent overrides
+			d := ts.Spec.Defaults
+
+			r.Type = "firecracker"
+			r.RAM = "6G"
+			r.VCPU = 4
+			r.Disk = "50G"
+			r.Mode = "normal"
+
+			if d != nil {
+				if d.Type != "" {
+					r.Type = d.Type
+				}
+				if d.RAM != "" {
+					r.RAM = d.RAM
+				}
+				if d.VCPU > 0 {
+					r.VCPU = d.VCPU
+				}
+				if d.Disk != "" {
+					r.Disk = d.Disk
+				}
+				if d.Mode != "" {
+					r.Mode = d.Mode
+				}
+				r.Repos = d.Repos
+				r.Authorized = d.Authorized
+				if d.Persona != nil {
+					p := *d.Persona
+					r.Persona = &p
+				}
+			}
+
+			// Agent-level overrides (replace, not merge)
+			if a.Type != "" {
+				r.Type = a.Type
+			}
+			if a.RAM != "" {
+				r.RAM = a.RAM
+			}
+			if a.VCPU > 0 {
+				r.VCPU = a.VCPU
+			}
+			if a.Disk != "" {
+				r.Disk = a.Disk
+			}
+			if a.Mode != "" {
+				r.Mode = a.Mode
+			}
+			if a.Repos != nil {
+				r.Repos = a.Repos
+			}
+			if a.Access != nil {
+				r.Access = a.Access
+			}
+			if a.Authorized != nil {
+				r.Authorized = *a.Authorized
+			}
+			if a.Persona != nil {
+				r.Persona = a.Persona
+			}
+
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// Summary returns a human-readable summary of what the team spec defines.
+func (ts *TeamSpec) Summary() string {
+	agents := ts.Resolve()
+	var b strings.Builder
+	fmt.Fprintf(&b, "Team: %s\n", ts.Metadata.Name)
+	if len(ts.Metadata.Labels) > 0 {
+		fmt.Fprintf(&b, "Labels: %v\n", ts.Metadata.Labels)
+	}
+	fmt.Fprintf(&b, "Agents: %d definitions → %d VMs\n\n", len(ts.Spec.Agents), len(agents))
+	for _, a := range agents {
+		fmt.Fprintf(&b, "  %-40s %s vcpu=%d ram=%s disk=%s mode=%s\n",
+			a.VMName, a.Type, a.VCPU, a.RAM, a.Disk, a.Mode)
+		if a.Persona != nil && a.Persona.Role != "" {
+			fmt.Fprintf(&b, "    persona: %s\n", a.Persona.Role)
+		}
+		if len(a.Repos) > 0 {
+			fmt.Fprintf(&b, "    repos: %s\n", strings.Join(a.Repos, ", "))
+		}
+		if len(a.Access) > 0 {
+			fmt.Fprintf(&b, "    access: %s\n", strings.Join(a.Access, ", "))
+		}
+	}
+	return b.String()
+}

--- a/host/internal/team/spec_test.go
+++ b/host/internal/team/spec_test.go
@@ -1,0 +1,245 @@
+package team
+
+import (
+	"testing"
+)
+
+const exampleYAML = `
+apiVersion: boxcutter/v1
+kind: Team
+metadata:
+  name: platform-team
+  labels:
+    project: boxcutter
+spec:
+  defaults:
+    type: firecracker
+    ram: 6G
+    vcpu: 4
+    mode: normal
+    repos:
+      - AndrewBudd/boxcutter
+    authorized: true
+
+  agents:
+    - name: eng-manager
+      ram: 4G
+      vcpu: 2
+      persona:
+        role: engineering-manager
+        claude_md: .claude/personas/eng-manager.md
+        instructions: |
+          You coordinate dev workers.
+      access:
+        - github-issues
+        - github-prs
+        - tapegun-sendkeys
+
+    - name: dev-worker
+      replicas: 3
+      persona:
+        role: developer
+        claude_md: .claude/personas/developer.md
+      access:
+        - github-issues
+        - github-prs
+
+    - name: product-manager
+      ram: 4G
+      vcpu: 2
+      persona:
+        role: product-manager
+        claude_md: .claude/personas/product-manager.md
+        instructions: |
+          You write specs, prioritize backlog.
+      access:
+        - github-issues
+        - github-projects
+`
+
+func TestParse_ValidYAML(t *testing.T) {
+	ts, err := Parse([]byte(exampleYAML))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if ts.Metadata.Name != "platform-team" {
+		t.Errorf("name = %q, want platform-team", ts.Metadata.Name)
+	}
+	if len(ts.Spec.Agents) != 3 {
+		t.Errorf("agents = %d, want 3", len(ts.Spec.Agents))
+	}
+	if ts.Spec.Agents[1].Replicas != 3 {
+		t.Errorf("dev-worker replicas = %d, want 3", ts.Spec.Agents[1].Replicas)
+	}
+}
+
+func TestParse_InvalidKind(t *testing.T) {
+	yaml := `
+apiVersion: boxcutter/v1
+kind: Cluster
+metadata:
+  name: test
+spec:
+  agents:
+    - name: a
+`
+	_, err := Parse([]byte(yaml))
+	if err == nil {
+		t.Fatal("expected error for wrong kind")
+	}
+}
+
+func TestParse_MissingName(t *testing.T) {
+	yaml := `
+apiVersion: boxcutter/v1
+kind: Team
+metadata:
+  name: ""
+spec:
+  agents:
+    - name: a
+`
+	_, err := Parse([]byte(yaml))
+	if err == nil {
+		t.Fatal("expected error for empty metadata.name")
+	}
+}
+
+func TestParse_NoAgents(t *testing.T) {
+	yaml := `
+apiVersion: boxcutter/v1
+kind: Team
+metadata:
+  name: test
+spec:
+  agents: []
+`
+	_, err := Parse([]byte(yaml))
+	if err == nil {
+		t.Fatal("expected error for empty agents")
+	}
+}
+
+func TestParse_AgentMissingName(t *testing.T) {
+	yaml := `
+apiVersion: boxcutter/v1
+kind: Team
+metadata:
+  name: test
+spec:
+  agents:
+    - replicas: 2
+`
+	_, err := Parse([]byte(yaml))
+	if err == nil {
+		t.Fatal("expected error for agent without name")
+	}
+}
+
+func TestResolve_DefaultsApplied(t *testing.T) {
+	ts, _ := Parse([]byte(exampleYAML))
+	agents := ts.Resolve()
+
+	// eng-manager overrides ram and vcpu
+	em := agents[0]
+	if em.VMName != "platform-team-eng-manager-1" {
+		t.Errorf("vmname = %q", em.VMName)
+	}
+	if em.RAM != "4G" {
+		t.Errorf("eng-manager RAM = %q, want 4G (override)", em.RAM)
+	}
+	if em.VCPU != 2 {
+		t.Errorf("eng-manager VCPU = %d, want 2 (override)", em.VCPU)
+	}
+	if em.Type != "firecracker" {
+		t.Errorf("eng-manager type = %q, want firecracker (default)", em.Type)
+	}
+	if !em.Authorized {
+		t.Error("eng-manager should inherit authorized=true from defaults")
+	}
+
+	// dev-worker inherits all defaults
+	dw := agents[1]
+	if dw.RAM != "6G" {
+		t.Errorf("dev-worker RAM = %q, want 6G (default)", dw.RAM)
+	}
+	if dw.VCPU != 4 {
+		t.Errorf("dev-worker VCPU = %d, want 4 (default)", dw.VCPU)
+	}
+}
+
+func TestResolve_ReplicaExpansion(t *testing.T) {
+	ts, _ := Parse([]byte(exampleYAML))
+	agents := ts.Resolve()
+
+	// 1 eng-manager + 3 dev-workers + 1 product-manager = 5
+	if len(agents) != 5 {
+		t.Fatalf("resolved agents = %d, want 5", len(agents))
+	}
+
+	// Check dev-worker replica naming
+	for i, idx := range []int{1, 2, 3} {
+		a := agents[1+i]
+		wantName := "platform-team-dev-worker-" + string(rune('0'+idx))
+		if a.VMName != wantName {
+			t.Errorf("replica %d name = %q, want %q", idx, a.VMName, wantName)
+		}
+		if a.ReplicaNum != idx {
+			t.Errorf("replica %d num = %d", idx, a.ReplicaNum)
+		}
+	}
+}
+
+func TestResolve_AccessReplaces(t *testing.T) {
+	ts, _ := Parse([]byte(exampleYAML))
+	agents := ts.Resolve()
+
+	// eng-manager has agent-level access, should not inherit default repos
+	em := agents[0]
+	if len(em.Access) != 3 {
+		t.Errorf("eng-manager access = %v, want 3 entries", em.Access)
+	}
+
+	// But repos come from defaults (eng-manager doesn't specify repos)
+	if len(em.Repos) != 1 || em.Repos[0] != "AndrewBudd/boxcutter" {
+		t.Errorf("eng-manager repos = %v, want [AndrewBudd/boxcutter] from defaults", em.Repos)
+	}
+}
+
+func TestResolve_PersonaOverride(t *testing.T) {
+	ts, _ := Parse([]byte(exampleYAML))
+	agents := ts.Resolve()
+
+	em := agents[0]
+	if em.Persona == nil || em.Persona.Role != "engineering-manager" {
+		t.Errorf("eng-manager persona role = %v", em.Persona)
+	}
+}
+
+func TestSummary(t *testing.T) {
+	ts, _ := Parse([]byte(exampleYAML))
+	s := ts.Summary()
+	if s == "" {
+		t.Fatal("summary should not be empty")
+	}
+	// Spot-check: should mention team name and VM names
+	if !contains(s, "platform-team") {
+		t.Error("summary missing team name")
+	}
+	if !contains(s, "platform-team-dev-worker-1") {
+		t.Error("summary missing expanded replica name")
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && searchString(s, sub)
+}
+
+func searchString(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Foundation for declarative team configuration while PM finalizes the spec.

- **New package `host/internal/team/`** — `TeamSpec` struct matching the YAML schema from the [PM spec comment on #94](https://github.com/AndrewBudd/boxcutter/issues/94), with parsing, validation, defaults resolution, and replica expansion
- **CLI subcommands** in `host/cmd/host/main.go`:
  - `team apply -f team.yaml` — parse spec, resolve defaults/replicas, show what VMs would be created (checks orchestrator for existing VMs)
  - `team destroy -f team.yaml` — show what VMs would be destroyed
  - `team list` — discover teams by scanning VM names from orchestrator
  - `team status -f team.yaml` — show status of each expected VM
- **All dry-run only** — no VMs created/destroyed. Reconciliation is a follow-up.
- **Unit tests** for YAML parsing, validation errors, defaults inheritance, replica expansion, access list replacement semantics

### YAML schema supported

```yaml
apiVersion: boxcutter/v1
kind: Team
metadata:
  name: platform-team
  labels: { project: boxcutter }
spec:
  defaults:
    type: firecracker
    ram: 6G
    vcpu: 4
    repos: [AndrewBudd/boxcutter]
    authorized: true
  agents:
    - name: eng-manager
      ram: 4G
      vcpu: 2
      persona: { role: engineering-manager, claude_md: .claude/personas/eng-manager.md }
      access: [github-issues, github-prs, tapegun-sendkeys]
    - name: dev-worker
      replicas: 3
      persona: { role: developer }
```

## Test plan

- [ ] `go test ./host/internal/team/...` passes
- [ ] `boxcutter-host team apply -f example.yaml` parses and prints plan
- [ ] `boxcutter-host team status -f example.yaml` shows VM status from orchestrator
- [ ] Invalid YAML (missing name, wrong kind, empty agents) produces clear errors

Ref #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)