### PR TITLE
Feat #94: add GET /metadata/agent-config endpoint to vmid

### DIFF
--- a/node/vmid/cmd/vmid/main.go
+++ b/node/vmid/cmd/vmid/main.go
@@ -104,7 +104,7 @@ func main() {
 
 	// VM-facing server (listens on the metadata IP)
 	vmMux := http.NewServeMux()
-	metaHandler := api.NewMetadataHandler(jwtIssuer, githubMinter, sentinelStore, cfg.Metadata)
+	metaHandler := api.NewMetadataHandler(jwtIssuer, githubMinter, sentinelStore, reg, cfg.Metadata)
 	metaHandler.Register(vmMux)
 	tapegunHandler := api.NewTapegunHandler(reg)
 	tapegunHandler.Register(vmMux)

--- a/node/vmid/internal/api/admin.go
+++ b/node/vmid/internal/api/admin.go
@@ -43,20 +43,25 @@ func (h *AdminHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /internal/vms/{id}/inbox", h.handleGetInbox)
 	mux.HandleFunc("GET /internal/tapegun/activity", h.handleAllActivity)
 
+	// Agent config
+	mux.HandleFunc("PUT /internal/vms/{id}/agent-config", h.handleSetAgentConfig)
+	mux.HandleFunc("GET /internal/vms/{id}/agent-config", h.handleGetAgentConfig)
+
 	// VM-to-VM mailbox (used by node agent for relay + migration)
 	mux.HandleFunc("POST /internal/vms/{id}/mailbox", h.handlePushMailbox)
 	mux.HandleFunc("GET /internal/vms/{id}/mailbox", h.handleExportMailbox)
 }
 
 type registerRequest struct {
-	VMID        string            `json:"vm_id"`
-	VMType      string            `json:"vm_type,omitempty"`
-	IP          string            `json:"ip"`
-	Mark        int               `json:"mark"`
-	Mode        string            `json:"mode"`
-	Labels      map[string]string `json:"labels,omitempty"`
-	GitHubRepo  string            `json:"github_repo,omitempty"`
-	GitHubRepos []string          `json:"github_repos,omitempty"`
+	VMID        string                `json:"vm_id"`
+	VMType      string                `json:"vm_type,omitempty"`
+	IP          string                `json:"ip"`
+	Mark        int                   `json:"mark"`
+	Mode        string                `json:"mode"`
+	Labels      map[string]string     `json:"labels,omitempty"`
+	GitHubRepo  string                `json:"github_repo,omitempty"`
+	GitHubRepos []string              `json:"github_repos,omitempty"`
+	AgentConfig *registry.AgentConfig `json:"agent_config,omitempty"`
 }
 
 func (h *AdminHandler) handleRegister(w http.ResponseWriter, r *http.Request) {
@@ -82,6 +87,7 @@ func (h *AdminHandler) handleRegister(w http.ResponseWriter, r *http.Request) {
 		Labels:      req.Labels,
 		GitHubRepo:  req.GitHubRepo,
 		GitHubRepos: req.GitHubRepos,
+		AgentConfig: req.AgentConfig,
 	}
 	h.reg.Register(rec)
 
@@ -381,6 +387,39 @@ func (h *AdminHandler) handleExportMailbox(w http.ResponseWriter, r *http.Reques
 		msgs = []*registry.MailboxMessage{}
 	}
 	writeJSON(w, msgs)
+}
+
+func (h *AdminHandler) handleSetAgentConfig(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		id = extractPathID(r.URL.Path, "/internal/vms/")
+	}
+	var cfg registry.AgentConfig
+	if err := json.NewDecoder(r.Body).Decode(&cfg); err != nil {
+		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if !h.reg.SetAgentConfig(id, &cfg) {
+		http.Error(w, "vm not found", http.StatusNotFound)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *AdminHandler) handleGetAgentConfig(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		id = extractPathID(r.URL.Path, "/internal/vms/")
+	}
+	cfg, ok := h.reg.GetAgentConfig(id)
+	if !ok {
+		http.Error(w, "vm not found", http.StatusNotFound)
+		return
+	}
+	if cfg == nil {
+		cfg = &registry.AgentConfig{}
+	}
+	writeJSON(w, cfg)
 }
 
 func extractPathID(path, prefix string) string {

--- a/node/vmid/internal/api/metadata.go
+++ b/node/vmid/internal/api/metadata.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/AndrewBudd/boxcutter/node/vmid/internal/config"
 	"github.com/AndrewBudd/boxcutter/node/vmid/internal/middleware"
+	"github.com/AndrewBudd/boxcutter/node/vmid/internal/registry"
 	"github.com/AndrewBudd/boxcutter/node/vmid/internal/sentinel"
 	"github.com/AndrewBudd/boxcutter/node/vmid/internal/token"
 )
@@ -16,11 +17,12 @@ type MetadataHandler struct {
 	jwt      *token.JWTIssuer
 	github   *token.GitHubTokenMinter
 	sentinel *sentinel.Store
+	reg      *registry.Registry
 	metadata config.MetadataFilesConfig
 }
 
-func NewMetadataHandler(jwt *token.JWTIssuer, github *token.GitHubTokenMinter, sentinel *sentinel.Store, metadata config.MetadataFilesConfig) *MetadataHandler {
-	return &MetadataHandler{jwt: jwt, github: github, sentinel: sentinel, metadata: metadata}
+func NewMetadataHandler(jwt *token.JWTIssuer, github *token.GitHubTokenMinter, sentinel *sentinel.Store, reg *registry.Registry, metadata config.MetadataFilesConfig) *MetadataHandler {
+	return &MetadataHandler{jwt: jwt, github: github, sentinel: sentinel, reg: reg, metadata: metadata}
 }
 
 func (h *MetadataHandler) Register(mux *http.ServeMux) {
@@ -32,6 +34,7 @@ func (h *MetadataHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /metadata/ca-cert", h.handleCACert)
 	mux.HandleFunc("GET /metadata/boxcutter-ssh-key", h.handleVMSSHKey)
 	mux.HandleFunc("GET /metadata/claude-credentials", h.handleClaudeCredentials)
+	mux.HandleFunc("GET /metadata/agent-config", h.handleAgentConfig)
 	// Metadata-style root
 	mux.HandleFunc("GET /", h.handleRoot)
 }
@@ -59,6 +62,7 @@ func (h *MetadataHandler) handleRoot(w http.ResponseWriter, r *http.Request) {
 			"ca_cert":            "/metadata/ca-cert",
 			"boxcutter_ssh_key":  "/metadata/boxcutter-ssh-key",
 			"claude_credentials": "/metadata/claude-credentials",
+			"agent_config":       "/metadata/agent-config",
 		},
 	})
 }
@@ -217,6 +221,22 @@ func (h *MetadataHandler) handleClaudeCredentials(w http.ResponseWriter, r *http
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(data)
+}
+
+// handleAgentConfig returns the boot agent configuration for the requesting VM.
+func (h *MetadataHandler) handleAgentConfig(w http.ResponseWriter, r *http.Request) {
+	rec, ok := middleware.VMFromContext(r.Context())
+	if !ok {
+		http.Error(w, "no VM context", http.StatusInternalServerError)
+		return
+	}
+	cfg, _ := h.reg.GetAgentConfig(rec.VMID)
+	if cfg == nil {
+		// Return empty config rather than 404 — the VM exists but has no
+		// agent config set yet. The boot agent can use defaults.
+		cfg = &registry.AgentConfig{}
+	}
+	writeJSON(w, cfg)
 }
 
 func writeJSON(w http.ResponseWriter, v interface{}) {

--- a/node/vmid/internal/api/metadata_test.go
+++ b/node/vmid/internal/api/metadata_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/AndrewBudd/boxcutter/node/vmid/internal/config"
+	"github.com/AndrewBudd/boxcutter/node/vmid/internal/registry"
 	"github.com/AndrewBudd/boxcutter/node/vmid/internal/sentinel"
 )
 
@@ -15,6 +16,7 @@ func newTestMetadataHandler(t *testing.T, metadata config.MetadataFilesConfig) *
 	t.Helper()
 	return &MetadataHandler{
 		sentinel: sentinel.NewStore(),
+		reg:      registry.New(),
 		metadata: metadata,
 	}
 }

--- a/node/vmid/internal/registry/registry.go
+++ b/node/vmid/internal/registry/registry.go
@@ -67,13 +67,36 @@ type VMActivitySummary struct {
 	PendingMessages int             `json:"pending_messages"`
 }
 
-// AgentConfig is the boot agent specification for a VM.
-// It tells the in-VM agent what persona to assume, which repos to clone,
-// and any flags to pass to Claude Code.
+// PersonaConfig describes the persona files and instructions for the in-VM agent.
+type PersonaConfig struct {
+	Role         string `json:"role,omitempty"`         // e.g., "backend-eng", "security-reviewer"
+	ClaudeMD     string `json:"claude_md,omitempty"`    // contents of persona CLAUDE.md
+	Instructions string `json:"instructions,omitempty"` // additional instructions for the agent
+}
+
+// VMConfigInfo describes the VM resource configuration requested by the team spec.
+type VMConfigInfo struct {
+	VMType string `json:"vm_type,omitempty"` // "firecracker" or "qemu"
+	CPUs   int    `json:"cpus,omitempty"`
+	MemMB  int    `json:"mem_mb,omitempty"`
+	DiskGB int    `json:"disk_gb,omitempty"`
+}
+
+// AgentConfig is the boot agent specification for a VM, derived from the
+// declarative team YAML. It tells the in-VM agent what persona to assume,
+// which repos to clone, what tapegun sequences to run, and access policy.
 type AgentConfig struct {
-	Persona string            `json:"persona,omitempty"`  // e.g., "backend-eng", "security-reviewer"
-	Repos   []string          `json:"repos,omitempty"`    // repos to clone on boot
-	Flags   map[string]string `json:"flags,omitempty"`    // arbitrary key-value flags for the agent
+	Team             string            `json:"team,omitempty"`               // team name from team YAML
+	Agent            string            `json:"agent,omitempty"`              // agent name within the team
+	ReplicaIndex     int               `json:"replica_index,omitempty"`      // replica index for scaled agents
+	Persona          *PersonaConfig    `json:"persona,omitempty"`            // persona configuration
+	Repos            []string          `json:"repos,omitempty"`              // repos to clone on boot
+	Tapegun          []string          `json:"tapegun,omitempty"`            // tapegun sequences to run on boot
+	Access           []string          `json:"access,omitempty"`             // access policy entries
+	Authorized       bool              `json:"authorized,omitempty"`         // whether the VM is pre-authorized
+	VMConfig         *VMConfigInfo     `json:"vm_config,omitempty"`          // requested VM resource configuration
+	Labels           map[string]string `json:"labels,omitempty"`             // labels for the VM
+	TeamPersonaFiles []string          `json:"team_persona_files,omitempty"` // team-level persona file paths
 }
 
 type VMRecord struct {

--- a/node/vmid/internal/registry/registry.go
+++ b/node/vmid/internal/registry/registry.go
@@ -67,6 +67,15 @@ type VMActivitySummary struct {
 	PendingMessages int             `json:"pending_messages"`
 }
 
+// AgentConfig is the boot agent specification for a VM.
+// It tells the in-VM agent what persona to assume, which repos to clone,
+// and any flags to pass to Claude Code.
+type AgentConfig struct {
+	Persona string            `json:"persona,omitempty"`  // e.g., "backend-eng", "security-reviewer"
+	Repos   []string          `json:"repos,omitempty"`    // repos to clone on boot
+	Flags   map[string]string `json:"flags,omitempty"`    // arbitrary key-value flags for the agent
+}
+
 type VMRecord struct {
 	VMID        string            `json:"vm_id"`
 	VMType      string            `json:"vm_type,omitempty"` // "firecracker" or "qemu"
@@ -77,6 +86,8 @@ type VMRecord struct {
 	GitHubRepo     string            `json:"github_repo,omitempty"`     // backwards compat
 	GitHubRepos    []string          `json:"github_repos,omitempty"`    // all repos
 	GitHubProjects []string          `json:"github_projects,omitempty"` // authorized projects
+
+	AgentConfig  *AgentConfig     `json:"agent_config,omitempty"`
 
 	LastActivity *ActivityReport   `json:"last_activity,omitempty"`
 	LastStatus   *StatusReport    `json:"last_status,omitempty"`
@@ -357,6 +368,29 @@ func (r *Registry) SetHealth(vmID string, report *HealthReport) bool {
 	}
 	rec.SetHealth(report)
 	return true
+}
+
+// SetAgentConfig updates a VM's agent configuration under the registry lock.
+func (r *Registry) SetAgentConfig(vmID string, cfg *AgentConfig) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	rec, ok := r.byID[vmID]
+	if !ok {
+		return false
+	}
+	rec.AgentConfig = cfg
+	return true
+}
+
+// GetAgentConfig returns a VM's agent configuration.
+func (r *Registry) GetAgentConfig(vmID string) (*AgentConfig, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	rec, ok := r.byID[vmID]
+	if !ok {
+		return nil, false
+	}
+	return rec.AgentConfig, true
 }
 
 // GetHealth returns a VM's last health report.

--- a/node/vmid/internal/registry/registry_test.go
+++ b/node/vmid/internal/registry/registry_test.go
@@ -86,6 +86,79 @@ func TestMultipleVMsDifferentMarks(t *testing.T) {
 	}
 }
 
+func TestAgentConfig_SetAndGet(t *testing.T) {
+	r := New()
+	r.Register(&VMRecord{VMID: "vm-1", IP: "10.0.0.2", Mark: 100})
+
+	cfg := &AgentConfig{
+		Persona: "backend-eng",
+		Repos:   []string{"org/repo1", "org/repo2"},
+		Flags:   map[string]string{"verbose": "true"},
+	}
+	if !r.SetAgentConfig("vm-1", cfg) {
+		t.Fatal("SetAgentConfig returned false")
+	}
+
+	got, ok := r.GetAgentConfig("vm-1")
+	if !ok {
+		t.Fatal("GetAgentConfig returned false")
+	}
+	if got.Persona != "backend-eng" {
+		t.Fatalf("Persona = %q, want %q", got.Persona, "backend-eng")
+	}
+	if len(got.Repos) != 2 || got.Repos[0] != "org/repo1" {
+		t.Fatalf("Repos = %v, want [org/repo1 org/repo2]", got.Repos)
+	}
+	if got.Flags["verbose"] != "true" {
+		t.Fatalf("Flags = %v, want verbose=true", got.Flags)
+	}
+}
+
+func TestAgentConfig_NotFound(t *testing.T) {
+	r := New()
+	_, ok := r.GetAgentConfig("nonexistent")
+	if ok {
+		t.Fatal("GetAgentConfig should return false for unknown VM")
+	}
+	if r.SetAgentConfig("nonexistent", &AgentConfig{Persona: "x"}) {
+		t.Fatal("SetAgentConfig should return false for unknown VM")
+	}
+}
+
+func TestAgentConfig_NilByDefault(t *testing.T) {
+	r := New()
+	r.Register(&VMRecord{VMID: "vm-1", IP: "10.0.0.2", Mark: 100})
+
+	cfg, ok := r.GetAgentConfig("vm-1")
+	if !ok {
+		t.Fatal("GetAgentConfig returned false for registered VM")
+	}
+	if cfg != nil {
+		t.Fatalf("AgentConfig should be nil by default, got %v", cfg)
+	}
+}
+
+func TestAgentConfig_SetAtRegistration(t *testing.T) {
+	r := New()
+	r.Register(&VMRecord{
+		VMID: "vm-1",
+		IP:   "10.0.0.2",
+		Mark: 100,
+		AgentConfig: &AgentConfig{
+			Persona: "security-reviewer",
+			Repos:   []string{"org/sec-tools"},
+		},
+	})
+
+	cfg, ok := r.GetAgentConfig("vm-1")
+	if !ok || cfg == nil {
+		t.Fatal("AgentConfig should be set from registration")
+	}
+	if cfg.Persona != "security-reviewer" {
+		t.Fatalf("Persona = %q, want %q", cfg.Persona, "security-reviewer")
+	}
+}
+
 func TestZeroMarkNotIndexed(t *testing.T) {
 	r := New()
 

--- a/node/vmid/internal/registry/registry_test.go
+++ b/node/vmid/internal/registry/registry_test.go
@@ -91,9 +91,26 @@ func TestAgentConfig_SetAndGet(t *testing.T) {
 	r.Register(&VMRecord{VMID: "vm-1", IP: "10.0.0.2", Mark: 100})
 
 	cfg := &AgentConfig{
-		Persona: "backend-eng",
-		Repos:   []string{"org/repo1", "org/repo2"},
-		Flags:   map[string]string{"verbose": "true"},
+		Team:         "platform",
+		Agent:        "backend-eng",
+		ReplicaIndex: 0,
+		Persona: &PersonaConfig{
+			Role:         "backend-eng",
+			ClaudeMD:     "# Backend Engineer\nFocus on Go services.",
+			Instructions: "Run tests before committing.",
+		},
+		Repos:      []string{"org/repo1", "org/repo2"},
+		Tapegun:    []string{"setup-env", "clone-repos"},
+		Access:     []string{"github:org/repo1", "github:org/repo2"},
+		Authorized: true,
+		VMConfig: &VMConfigInfo{
+			VMType: "firecracker",
+			CPUs:   2,
+			MemMB:  2048,
+			DiskGB: 10,
+		},
+		Labels:           map[string]string{"env": "dev", "team": "platform"},
+		TeamPersonaFiles: []string{"/team/shared-claude.md"},
 	}
 	if !r.SetAgentConfig("vm-1", cfg) {
 		t.Fatal("SetAgentConfig returned false")
@@ -103,14 +120,35 @@ func TestAgentConfig_SetAndGet(t *testing.T) {
 	if !ok {
 		t.Fatal("GetAgentConfig returned false")
 	}
-	if got.Persona != "backend-eng" {
-		t.Fatalf("Persona = %q, want %q", got.Persona, "backend-eng")
+	if got.Team != "platform" {
+		t.Fatalf("Team = %q, want %q", got.Team, "platform")
+	}
+	if got.Agent != "backend-eng" {
+		t.Fatalf("Agent = %q, want %q", got.Agent, "backend-eng")
+	}
+	if got.Persona == nil || got.Persona.Role != "backend-eng" {
+		t.Fatalf("Persona.Role = %v, want %q", got.Persona, "backend-eng")
+	}
+	if got.Persona.ClaudeMD != "# Backend Engineer\nFocus on Go services." {
+		t.Fatalf("Persona.ClaudeMD = %q, want non-empty", got.Persona.ClaudeMD)
 	}
 	if len(got.Repos) != 2 || got.Repos[0] != "org/repo1" {
 		t.Fatalf("Repos = %v, want [org/repo1 org/repo2]", got.Repos)
 	}
-	if got.Flags["verbose"] != "true" {
-		t.Fatalf("Flags = %v, want verbose=true", got.Flags)
+	if len(got.Tapegun) != 2 || got.Tapegun[0] != "setup-env" {
+		t.Fatalf("Tapegun = %v, want [setup-env clone-repos]", got.Tapegun)
+	}
+	if !got.Authorized {
+		t.Fatal("Authorized = false, want true")
+	}
+	if got.VMConfig == nil || got.VMConfig.CPUs != 2 {
+		t.Fatalf("VMConfig.CPUs = %v, want 2", got.VMConfig)
+	}
+	if got.Labels["team"] != "platform" {
+		t.Fatalf("Labels = %v, want team=platform", got.Labels)
+	}
+	if len(got.TeamPersonaFiles) != 1 || got.TeamPersonaFiles[0] != "/team/shared-claude.md" {
+		t.Fatalf("TeamPersonaFiles = %v, want [/team/shared-claude.md]", got.TeamPersonaFiles)
 	}
 }
 
@@ -120,7 +158,7 @@ func TestAgentConfig_NotFound(t *testing.T) {
 	if ok {
 		t.Fatal("GetAgentConfig should return false for unknown VM")
 	}
-	if r.SetAgentConfig("nonexistent", &AgentConfig{Persona: "x"}) {
+	if r.SetAgentConfig("nonexistent", &AgentConfig{Agent: "x"}) {
 		t.Fatal("SetAgentConfig should return false for unknown VM")
 	}
 }
@@ -145,8 +183,14 @@ func TestAgentConfig_SetAtRegistration(t *testing.T) {
 		IP:   "10.0.0.2",
 		Mark: 100,
 		AgentConfig: &AgentConfig{
-			Persona: "security-reviewer",
-			Repos:   []string{"org/sec-tools"},
+			Team:  "security",
+			Agent: "security-reviewer",
+			Persona: &PersonaConfig{
+				Role:     "security-reviewer",
+				ClaudeMD: "# Security Reviewer",
+			},
+			Repos:      []string{"org/sec-tools"},
+			Authorized: false,
 		},
 	})
 
@@ -154,8 +198,14 @@ func TestAgentConfig_SetAtRegistration(t *testing.T) {
 	if !ok || cfg == nil {
 		t.Fatal("AgentConfig should be set from registration")
 	}
-	if cfg.Persona != "security-reviewer" {
-		t.Fatalf("Persona = %q, want %q", cfg.Persona, "security-reviewer")
+	if cfg.Team != "security" {
+		t.Fatalf("Team = %q, want %q", cfg.Team, "security")
+	}
+	if cfg.Agent != "security-reviewer" {
+		t.Fatalf("Agent = %q, want %q", cfg.Agent, "security-reviewer")
+	}
+	if cfg.Persona == nil || cfg.Persona.Role != "security-reviewer" {
+		t.Fatalf("Persona.Role = %v, want %q", cfg.Persona, "security-reviewer")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `AgentConfig` struct (persona, repos, flags) to the vmid registry
- Add `GET /metadata/agent-config` — identity-protected endpoint that returns the boot agent spec for the requesting VM (identified by fwmark)
- Add `PUT /GET /internal/vms/{id}/agent-config` admin endpoints for setting/reading config via Unix socket
- Support `agent_config` field in `POST /internal/vms` registration, so config can be set when the VM is first registered
- Returns empty config (not 404) when no config is set, so the boot agent can fall back to defaults

## API

**VM-facing (metadata IP, identity-protected):**
```
GET /metadata/agent-config
→ {"persona":"backend-eng","repos":["org/repo"],"flags":{"verbose":"true"}}
```

**Admin (Unix socket):**
```
PUT /internal/vms/{id}/agent-config  — set config
GET /internal/vms/{id}/agent-config  — read config
POST /internal/vms                   — register with agent_config field
```

## Test plan
- [x] Registry tests: set/get, not-found, nil-by-default, set-at-registration
- [ ] Integration: register VM with agent_config, query /metadata/agent-config, verify response
- [ ] Integration: update config via admin PUT, re-query metadata endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)