### PR TITLE
Fix #105: orchestrator team apply/destroy/list/status commands

### DIFF
--- a/orchestrator/internal/api/handlers.go
+++ b/orchestrator/internal/api/handlers.go
@@ -345,17 +345,18 @@ func (h *Handler) handleNodeGet(w http.ResponseWriter, r *http.Request) {
 // --- VM handlers ---
 
 type vmCreateRequest struct {
-	Name             string   `json:"name"`
-	Type             string   `json:"type,omitempty"`
-	Description      string   `json:"description,omitempty"`
-	VCPU             int      `json:"vcpu,omitempty"`
-	RAMMIB           int      `json:"ram_mib,omitempty"`
-	Disk             string   `json:"disk,omitempty"`
-	CloneURL         string   `json:"clone_url,omitempty"`
-	CloneURLs        []string `json:"clone_urls,omitempty"`
-	Mode             string   `json:"mode,omitempty"`
-	NodeID           string   `json:"node_id,omitempty"`
-	TailscaleAuthkey string   `json:"tailscale_authkey,omitempty"`
+	Name             string            `json:"name"`
+	Type             string            `json:"type,omitempty"`
+	Description      string            `json:"description,omitempty"`
+	VCPU             int               `json:"vcpu,omitempty"`
+	RAMMIB           int               `json:"ram_mib,omitempty"`
+	Disk             string            `json:"disk,omitempty"`
+	CloneURL         string            `json:"clone_url,omitempty"`
+	CloneURLs        []string          `json:"clone_urls,omitempty"`
+	Mode             string            `json:"mode,omitempty"`
+	NodeID           string            `json:"node_id,omitempty"`
+	TailscaleAuthkey string            `json:"tailscale_authkey,omitempty"`
+	Labels           map[string]string `json:"labels,omitempty"`
 }
 
 // nodeToScheduler converts a state.Node to the db.Node type used by the scheduler.
@@ -534,6 +535,7 @@ func (h *Handler) handleVMCreate(w http.ResponseWriter, r *http.Request) {
 		Name:   nodeResp.Name,
 		NodeID: targetNode.ID,
 		Status: nodeResp.Status,
+		Labels: req.Labels,
 	})
 
 	log.Printf("VM created: %s on node %s", nodeResp.Name, targetNode.ID)

--- a/orchestrator/internal/ssh/handler.go
+++ b/orchestrator/internal/ssh/handler.go
@@ -8,8 +8,11 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 	"time"
+
+	"github.com/AndrewBudd/boxcutter/orchestrator/internal/team"
 )
 
 // Handler dispatches SSH ForceCommand actions to the orchestrator HTTP API.
@@ -137,6 +140,8 @@ func (h *Handler) Run(args []string) int {
 			return 1
 		}
 		return h.cmdCopyFrom(args[1], args[2], args[3])
+	case "team":
+		return h.cmdTeam(args[1:])
 	case "help":
 		h.printHelp()
 		return 0
@@ -876,6 +881,332 @@ echo "ok"`
 	return 0
 }
 
+// --- Team commands ---
+
+func (h *Handler) cmdTeam(args []string) int {
+	if len(args) == 0 {
+		fmt.Println(`Usage: ssh <host> team <subcommand>
+
+Subcommands:
+  apply -f -          Create/update team from YAML (reads stdin)
+  destroy <name>      Destroy all VMs for a team
+  list                List active teams
+  status <name>       Show status of team VMs`)
+		return 1
+	}
+
+	switch args[0] {
+	case "apply":
+		return h.teamApply(args[1:])
+	case "destroy":
+		return h.teamDestroy(args[1:])
+	case "list":
+		return h.teamList(args[1:])
+	case "status":
+		return h.teamStatus(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown team subcommand: %s\n", args[0])
+		return 1
+	}
+}
+
+func (h *Handler) teamApply(args []string) int {
+	// Parse -f flag. Only -f - (stdin) is supported.
+	file := ""
+	for i := 0; i < len(args); i++ {
+		if args[i] == "-f" && i+1 < len(args) {
+			file = args[i+1]
+			i++
+		}
+	}
+	if file == "" {
+		fmt.Fprintf(os.Stderr, "Usage: ssh <host> team apply -f -\n")
+		fmt.Fprintf(os.Stderr, "  Reads team YAML from stdin. Pipe with: cat team.yaml | ssh <host> team apply -f -\n")
+		return 1
+	}
+
+	var data []byte
+	var err error
+	if file == "-" {
+		data, err = io.ReadAll(os.Stdin)
+	} else {
+		fmt.Fprintf(os.Stderr, "Error: only -f - (stdin) is supported. File paths are not available on the orchestrator.\n")
+		fmt.Fprintf(os.Stderr, "Usage: cat team.yaml | ssh <host> team apply -f -\n")
+		return 1
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading stdin: %v\n", err)
+		return 1
+	}
+
+	ts, err := team.Parse(data)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+
+	agents := ts.Resolve()
+	fmt.Printf("Team: %s\n", ts.Metadata.Name)
+	fmt.Printf("Agents: %d definitions → %d VMs\n\n", len(ts.Spec.Agents), len(agents))
+
+	// Fetch existing VMs to determine create vs noop
+	existingVMs := make(map[string]bool)
+	resp, err := h.get("/api/vms")
+	if err == nil {
+		var vms []map[string]interface{}
+		json.Unmarshal(resp, &vms)
+		for _, vm := range vms {
+			if name, ok := vm["name"].(string); ok {
+				existingVMs[name] = true
+			}
+		}
+	}
+
+	// Compute diff
+	var toCreate []team.ResolvedAgent
+	var existing []string
+	for _, a := range agents {
+		if existingVMs[a.VMName] {
+			existing = append(existing, a.VMName)
+		} else {
+			toCreate = append(toCreate, a)
+		}
+	}
+
+	// Find VMs to destroy (scale-down): existing team VMs not in the spec
+	wantVMs := make(map[string]bool)
+	for _, a := range agents {
+		wantVMs[a.VMName] = true
+	}
+	var toDestroy []string
+	if resp != nil {
+		var vms []map[string]interface{}
+		json.Unmarshal(resp, &vms)
+		for _, vm := range vms {
+			name, _ := vm["name"].(string)
+			// Check if this VM belongs to this team by name prefix
+			if strings.HasPrefix(name, ts.Metadata.Name+"-") && !wantVMs[name] {
+				toDestroy = append(toDestroy, name)
+			}
+		}
+	}
+	// Destroy highest-indexed first
+	sort.Sort(sort.Reverse(sort.StringSlice(toDestroy)))
+
+	// Report plan
+	for _, name := range existing {
+		fmt.Printf("  ok       %s\n", name)
+	}
+
+	// Create new VMs
+	created := 0
+	for _, a := range toCreate {
+		body := map[string]interface{}{
+			"name":    a.VMName,
+			"type":    a.Type,
+			"vcpu":    a.VCPU,
+			"ram_mib": a.RAMMiB(),
+			"disk":    a.Disk,
+			"mode":    a.Mode,
+			"labels":  a.Labels(ts.Metadata.Name),
+		}
+		if a.Description != "" {
+			body["description"] = a.Description
+		}
+		urls := a.CloneURLs()
+		if len(urls) == 1 {
+			body["clone_url"] = urls[0]
+		} else if len(urls) > 1 {
+			body["clone_urls"] = urls
+		}
+
+		fmt.Printf("  create   %s ...", a.VMName)
+		_, err := h.postStream("/api/vms", body, func(evt map[string]interface{}) {
+			// suppress progress for batch creation
+		})
+		if err != nil {
+			fmt.Printf(" FAILED: %v\n", err)
+			continue
+		}
+		fmt.Printf(" ok\n")
+		created++
+	}
+
+	// Destroy scale-down VMs
+	destroyed := 0
+	for _, name := range toDestroy {
+		fmt.Printf("  destroy  %s ...", name)
+		_, err := h.delete("/api/vms/" + name)
+		if err != nil {
+			fmt.Printf(" FAILED: %v\n", err)
+			continue
+		}
+		fmt.Printf(" ok\n")
+		destroyed++
+	}
+
+	fmt.Printf("\nResult: %d created, %d existing, %d destroyed\n", created, len(existing), destroyed)
+	return 0
+}
+
+func (h *Handler) teamDestroy(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "Usage: ssh <host> team destroy <team-name>\n")
+		return 1
+	}
+	teamName := args[0]
+
+	// Find all VMs for this team by name prefix
+	resp, err := h.get("/api/vms")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error listing VMs: %v\n", err)
+		return 1
+	}
+
+	var vms []map[string]interface{}
+	json.Unmarshal(resp, &vms)
+
+	var targets []string
+	prefix := teamName + "-"
+	for _, vm := range vms {
+		name, _ := vm["name"].(string)
+		if strings.HasPrefix(name, prefix) {
+			targets = append(targets, name)
+		}
+	}
+
+	if len(targets) == 0 {
+		fmt.Printf("No VMs found for team %q\n", teamName)
+		return 0
+	}
+
+	// Destroy highest-indexed first
+	sort.Sort(sort.Reverse(sort.StringSlice(targets)))
+
+	fmt.Printf("Destroying %d VMs for team %q:\n\n", len(targets), teamName)
+	destroyed := 0
+	for _, name := range targets {
+		fmt.Printf("  destroy  %s ...", name)
+		_, err := h.delete("/api/vms/" + name)
+		if err != nil {
+			fmt.Printf(" FAILED: %v\n", err)
+			continue
+		}
+		fmt.Printf(" ok\n")
+		destroyed++
+	}
+
+	fmt.Printf("\nDestroyed %d/%d VMs\n", destroyed, len(targets))
+	return 0
+}
+
+func (h *Handler) teamList(_ []string) int {
+	resp, err := h.get("/api/vms")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error listing VMs: %v\n", err)
+		return 1
+	}
+
+	var vms []map[string]interface{}
+	json.Unmarshal(resp, &vms)
+
+	// Group VMs by team name prefix heuristic:
+	// team VMs are named {team}-{agent}-{N}
+	teams := make(map[string][]string)
+	for _, vm := range vms {
+		name, _ := vm["name"].(string)
+		parts := strings.Split(name, "-")
+		if len(parts) >= 3 {
+			// Check if last part is a number (replica index)
+			last := parts[len(parts)-1]
+			isNum := true
+			for _, c := range last {
+				if c < '0' || c > '9' {
+					isNum = false
+					break
+				}
+			}
+			if isNum && len(last) > 0 {
+				// Team name is everything before the last two segments
+				teamName := strings.Join(parts[:len(parts)-2], "-")
+				teams[teamName] = append(teams[teamName], name)
+			}
+		}
+	}
+
+	if len(teams) == 0 {
+		fmt.Println("No teams found")
+		return 0
+	}
+
+	// Sort team names
+	var teamNames []string
+	for name := range teams {
+		teamNames = append(teamNames, name)
+	}
+	sort.Strings(teamNames)
+
+	fmt.Printf("%-30s  %s\n", "TEAM", "VMs")
+	for _, name := range teamNames {
+		fmt.Printf("%-30s  %d\n", name, len(teams[name]))
+	}
+	return 0
+}
+
+func (h *Handler) teamStatus(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "Usage: ssh <host> team status <team-name>\n")
+		return 1
+	}
+	teamName := args[0]
+
+	resp, err := h.get("/api/vms")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error listing VMs: %v\n", err)
+		return 1
+	}
+
+	var vms []map[string]interface{}
+	json.Unmarshal(resp, &vms)
+
+	prefix := teamName + "-"
+	var teamVMs []map[string]interface{}
+	for _, vm := range vms {
+		name, _ := vm["name"].(string)
+		if strings.HasPrefix(name, prefix) {
+			teamVMs = append(teamVMs, vm)
+		}
+	}
+
+	if len(teamVMs) == 0 {
+		fmt.Printf("No VMs found for team %q\n", teamName)
+		return 0
+	}
+
+	fmt.Printf("Team: %s (%d VMs)\n\n", teamName, len(teamVMs))
+	fmt.Printf("%-35s  %-12s  %-12s  %-6s  %-5s  %s\n",
+		"NAME", "STATUS", "NODE", "TYPE", "VCPU", "RAM")
+	for _, vm := range teamVMs {
+		name, _ := vm["name"].(string)
+		status, _ := vm["status"].(string)
+		nodeName, _ := vm["node_name"].(string)
+		vmType, _ := vm["type"].(string)
+		vcpu, _ := vm["vcpu"].(float64)
+		ramMIB, _ := vm["ram_mib"].(float64)
+
+		if vmType == "" || vmType == "firecracker" {
+			vmType = "fc"
+		}
+		if status == "" {
+			status = "unknown"
+		}
+
+		fmt.Printf("%-35s  %-12s  %-12s  %-6s  %-5.0f  %s\n",
+			name, status, nodeName, vmType, vcpu, formatRAM(ramMIB))
+	}
+	return 0
+}
+
 func (h *Handler) printHelp() {
 	fmt.Print(`Boxcutter — ephemeral dev environments
 
@@ -927,6 +1258,10 @@ Commands:
                           Copy a file into a VM (use - for stdin)
   cp-from <name> <src> <dst>
                           Copy a file out of a VM (use - for stdout)
+  team apply -f -         Create/update team from YAML (stdin)
+  team destroy <name>     Destroy all VMs for a team
+  team list               List active teams
+  team status <name>      Show status of team VMs
   help                    Show this help
 
 Usage: ssh <host> <command> [args]

--- a/orchestrator/internal/state/state.go
+++ b/orchestrator/internal/state/state.go
@@ -28,9 +28,10 @@ type Node struct {
 
 // VM is a lightweight record mapping a VM name to its node.
 type VM struct {
-	Name   string `json:"name"`
-	NodeID string `json:"node_id"`
-	Status string `json:"status"`
+	Name   string            `json:"name"`
+	NodeID string            `json:"node_id"`
+	Status string            `json:"status"`
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // GoldenImage tracks which golden image versions exist on which nodes.
@@ -164,6 +165,20 @@ func (s *Store) ListVMs() []*VM {
 	return vms
 }
 
+// ListVMsByLabel returns all VMs matching the given label key=value.
+func (s *Store) ListVMsByLabel(key, value string) []*VM {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []*VM
+	for _, v := range s.vms {
+		if v.Labels != nil && v.Labels[key] == value {
+			copy := *v
+			out = append(out, &copy)
+		}
+	}
+	return out
+}
+
 // DeleteVM removes a VM from the store.
 func (s *Store) DeleteVM(name string) {
 	s.mu.Lock()
@@ -186,20 +201,28 @@ func (s *Store) SyncNodeVMs(nodeID string, vms []VM) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Remove existing VMs for this node
+	// Save existing VMs' labels before removal
+	old := make(map[string]*VM)
 	for name, v := range s.vms {
 		if v.NodeID == nodeID {
+			old[name] = v
 			delete(s.vms, name)
 		}
 	}
 
-	// Add the current VMs
+	// Add the current VMs, preserving labels from previous state
 	for i := range vms {
-		s.vms[vms[i].Name] = &VM{
+		vm := &VM{
 			Name:   vms[i].Name,
 			NodeID: vms[i].NodeID,
 			Status: vms[i].Status,
 		}
+		if vms[i].Labels != nil {
+			vm.Labels = vms[i].Labels
+		} else if prev, ok := old[vms[i].Name]; ok {
+			vm.Labels = prev.Labels
+		}
+		s.vms[vms[i].Name] = vm
 	}
 }
 

--- a/orchestrator/internal/team/spec.go
+++ b/orchestrator/internal/team/spec.go
@@ -1,0 +1,247 @@
+package team
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TeamSpec is the top-level structure for a team YAML file.
+type TeamSpec struct {
+	APIVersion string   `yaml:"apiVersion"`
+	Kind       string   `yaml:"kind"`
+	Metadata   Metadata `yaml:"metadata"`
+	Spec       Spec     `yaml:"spec"`
+}
+
+type Metadata struct {
+	Name   string            `yaml:"name"`
+	Labels map[string]string `yaml:"labels,omitempty"`
+}
+
+type Spec struct {
+	Defaults *AgentDefaults `yaml:"defaults,omitempty"`
+	Agents   []AgentSpec    `yaml:"agents"`
+}
+
+// AgentDefaults holds shared defaults inherited by all agents.
+// Agent-level values override defaults. List fields (repos, access, tapegun)
+// are replaced, not merged.
+type AgentDefaults struct {
+	Type       string   `yaml:"type,omitempty"`
+	RAM        string   `yaml:"ram,omitempty"`
+	VCPU       int      `yaml:"vcpu,omitempty"`
+	Disk       string   `yaml:"disk,omitempty"`
+	Mode       string   `yaml:"mode,omitempty"`
+	Repos      []string `yaml:"repos,omitempty"`
+	Authorized bool     `yaml:"authorized,omitempty"`
+	Persona    *Persona `yaml:"persona,omitempty"`
+	Tapegun    []string `yaml:"tapegun,omitempty"`
+}
+
+type AgentSpec struct {
+	Name        string   `yaml:"name"`
+	Replicas    int      `yaml:"replicas,omitempty"`
+	RAM         string   `yaml:"ram,omitempty"`
+	VCPU        int      `yaml:"vcpu,omitempty"`
+	Disk        string   `yaml:"disk,omitempty"`
+	Type        string   `yaml:"type,omitempty"`
+	Mode        string   `yaml:"mode,omitempty"`
+	Description string   `yaml:"description,omitempty"`
+	Persona     *Persona `yaml:"persona,omitempty"`
+	Repos       []string `yaml:"repos,omitempty"`
+	Access      []string `yaml:"access,omitempty"`
+	Authorized  *bool    `yaml:"authorized,omitempty"`
+	Tapegun     []string `yaml:"tapegun,omitempty"`
+}
+
+type Persona struct {
+	Role         string `yaml:"role,omitempty"`
+	ClaudeMD     string `yaml:"claude_md,omitempty"`
+	Instructions string `yaml:"instructions,omitempty"`
+}
+
+// Parse parses team YAML bytes.
+func Parse(data []byte) (*TeamSpec, error) {
+	var ts TeamSpec
+	if err := yaml.Unmarshal(data, &ts); err != nil {
+		return nil, fmt.Errorf("parsing YAML: %w", err)
+	}
+	if ts.Kind != "Team" {
+		return nil, fmt.Errorf("expected kind: Team, got %q", ts.Kind)
+	}
+	if ts.Metadata.Name == "" {
+		return nil, fmt.Errorf("metadata.name is required")
+	}
+	if len(ts.Spec.Agents) == 0 {
+		return nil, fmt.Errorf("spec.agents must contain at least one agent")
+	}
+	for i, a := range ts.Spec.Agents {
+		if a.Name == "" {
+			return nil, fmt.Errorf("spec.agents[%d].name is required", i)
+		}
+	}
+	return &ts, nil
+}
+
+// ResolvedAgent is an agent spec with defaults applied and replicas expanded.
+type ResolvedAgent struct {
+	VMName      string
+	AgentName   string
+	ReplicaNum  int
+	Type        string
+	RAM         string
+	VCPU        int
+	Disk        string
+	Mode        string
+	Description string
+	Persona     *Persona
+	Repos       []string
+	Access      []string
+	Authorized  bool
+	Tapegun     []string
+}
+
+// RAMMiB parses the human-readable RAM string (e.g. "4G", "2048M") to MiB.
+func (r *ResolvedAgent) RAMMiB() int {
+	return ParseRAMMiB(r.RAM)
+}
+
+// ParseRAMMiB converts a human-readable RAM string to MiB.
+func ParseRAMMiB(s string) int {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	s = strings.ToUpper(s)
+	if strings.HasSuffix(s, "G") {
+		if n, err := strconv.Atoi(s[:len(s)-1]); err == nil {
+			return n * 1024
+		}
+	}
+	if strings.HasSuffix(s, "M") {
+		if n, err := strconv.Atoi(s[:len(s)-1]); err == nil {
+			return n
+		}
+	}
+	if n, err := strconv.Atoi(s); err == nil {
+		return n
+	}
+	return 0
+}
+
+// CloneURLs builds GitHub clone URLs from the Repos list.
+func (r *ResolvedAgent) CloneURLs() []string {
+	var urls []string
+	for _, repo := range r.Repos {
+		if strings.HasPrefix(repo, "http") || strings.HasPrefix(repo, "git@") {
+			urls = append(urls, repo)
+		} else {
+			urls = append(urls, "https://github.com/"+repo+".git")
+		}
+	}
+	return urls
+}
+
+// Labels returns the metadata labels for this VM.
+func (r *ResolvedAgent) Labels(teamName string) map[string]string {
+	labels := map[string]string{
+		"team":          teamName,
+		"agent":         r.AgentName,
+		"replica_index": fmt.Sprintf("%d", r.ReplicaNum),
+	}
+	if r.Persona != nil && r.Persona.Role != "" {
+		labels["role"] = r.Persona.Role
+	}
+	return labels
+}
+
+// Resolve applies defaults and expands replicas into concrete VM definitions.
+func (ts *TeamSpec) Resolve() []ResolvedAgent {
+	var out []ResolvedAgent
+	for _, a := range ts.Spec.Agents {
+		replicas := a.Replicas
+		if replicas < 1 {
+			replicas = 1
+		}
+		for i := 1; i <= replicas; i++ {
+			r := ResolvedAgent{
+				VMName:      fmt.Sprintf("%s-%s-%d", ts.Metadata.Name, a.Name, i),
+				AgentName:   a.Name,
+				ReplicaNum:  i,
+				Description: a.Description,
+			}
+
+			// Apply defaults, then agent overrides
+			d := ts.Spec.Defaults
+
+			r.Type = "firecracker"
+			r.RAM = "6G"
+			r.VCPU = 4
+			r.Disk = "50G"
+			r.Mode = "normal"
+
+			if d != nil {
+				if d.Type != "" {
+					r.Type = d.Type
+				}
+				if d.RAM != "" {
+					r.RAM = d.RAM
+				}
+				if d.VCPU > 0 {
+					r.VCPU = d.VCPU
+				}
+				if d.Disk != "" {
+					r.Disk = d.Disk
+				}
+				if d.Mode != "" {
+					r.Mode = d.Mode
+				}
+				r.Repos = d.Repos
+				r.Authorized = d.Authorized
+				r.Tapegun = d.Tapegun
+				if d.Persona != nil {
+					p := *d.Persona
+					r.Persona = &p
+				}
+			}
+
+			// Agent-level overrides (replace, not merge)
+			if a.Type != "" {
+				r.Type = a.Type
+			}
+			if a.RAM != "" {
+				r.RAM = a.RAM
+			}
+			if a.VCPU > 0 {
+				r.VCPU = a.VCPU
+			}
+			if a.Disk != "" {
+				r.Disk = a.Disk
+			}
+			if a.Mode != "" {
+				r.Mode = a.Mode
+			}
+			if a.Repos != nil {
+				r.Repos = a.Repos
+			}
+			if a.Access != nil {
+				r.Access = a.Access
+			}
+			if a.Authorized != nil {
+				r.Authorized = *a.Authorized
+			}
+			if a.Persona != nil {
+				r.Persona = a.Persona
+			}
+			if a.Tapegun != nil {
+				r.Tapegun = a.Tapegun
+			}
+
+			out = append(out, r)
+		}
+	}
+	return out
+}

--- a/orchestrator/internal/team/spec_test.go
+++ b/orchestrator/internal/team/spec_test.go
@@ -1,0 +1,231 @@
+package team
+
+import (
+	"strings"
+	"testing"
+)
+
+const exampleYAML = `
+apiVersion: boxcutter/v1
+kind: Team
+metadata:
+  name: platform-team
+  labels:
+    project: boxcutter
+spec:
+  defaults:
+    type: firecracker
+    ram: 6G
+    vcpu: 4
+    mode: normal
+    repos:
+      - AndrewBudd/boxcutter
+    authorized: true
+
+  agents:
+    - name: eng-manager
+      ram: 4G
+      vcpu: 2
+      persona:
+        role: engineering-manager
+        claude_md: .claude/personas/eng-manager.md
+        instructions: |
+          You coordinate dev workers.
+      access:
+        - github-issues
+        - github-prs
+        - tapegun-sendkeys
+
+    - name: dev-worker
+      replicas: 3
+      persona:
+        role: developer
+        claude_md: .claude/personas/developer.md
+      access:
+        - github-issues
+        - github-prs
+
+    - name: product-manager
+      ram: 4G
+      vcpu: 2
+      persona:
+        role: product-manager
+        claude_md: .claude/personas/product-manager.md
+        instructions: |
+          You write specs, prioritize backlog.
+      access:
+        - github-issues
+        - github-projects
+`
+
+func TestParse_ValidYAML(t *testing.T) {
+	ts, err := Parse([]byte(exampleYAML))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if ts.Metadata.Name != "platform-team" {
+		t.Errorf("name = %q, want platform-team", ts.Metadata.Name)
+	}
+	if len(ts.Spec.Agents) != 3 {
+		t.Errorf("agents = %d, want 3", len(ts.Spec.Agents))
+	}
+	if ts.Spec.Agents[1].Replicas != 3 {
+		t.Errorf("dev-worker replicas = %d, want 3", ts.Spec.Agents[1].Replicas)
+	}
+}
+
+func TestParse_InvalidKind(t *testing.T) {
+	_, err := Parse([]byte(`
+apiVersion: boxcutter/v1
+kind: Cluster
+metadata:
+  name: test
+spec:
+  agents:
+    - name: a
+`))
+	if err == nil {
+		t.Fatal("expected error for wrong kind")
+	}
+}
+
+func TestParse_MissingName(t *testing.T) {
+	_, err := Parse([]byte(`
+apiVersion: boxcutter/v1
+kind: Team
+metadata:
+  name: ""
+spec:
+  agents:
+    - name: a
+`))
+	if err == nil {
+		t.Fatal("expected error for empty metadata.name")
+	}
+}
+
+func TestParse_NoAgents(t *testing.T) {
+	_, err := Parse([]byte(`
+apiVersion: boxcutter/v1
+kind: Team
+metadata:
+  name: test
+spec:
+  agents: []
+`))
+	if err == nil {
+		t.Fatal("expected error for empty agents")
+	}
+}
+
+func TestResolve_DefaultsApplied(t *testing.T) {
+	ts, _ := Parse([]byte(exampleYAML))
+	agents := ts.Resolve()
+
+	em := agents[0]
+	if em.VMName != "platform-team-eng-manager-1" {
+		t.Errorf("vmname = %q", em.VMName)
+	}
+	if em.RAM != "4G" {
+		t.Errorf("eng-manager RAM = %q, want 4G (override)", em.RAM)
+	}
+	if em.VCPU != 2 {
+		t.Errorf("eng-manager VCPU = %d, want 2 (override)", em.VCPU)
+	}
+	if em.Type != "firecracker" {
+		t.Errorf("eng-manager type = %q, want firecracker (default)", em.Type)
+	}
+	if !em.Authorized {
+		t.Error("eng-manager should inherit authorized=true from defaults")
+	}
+
+	// dev-worker inherits all defaults
+	dw := agents[1]
+	if dw.RAM != "6G" {
+		t.Errorf("dev-worker RAM = %q, want 6G (default)", dw.RAM)
+	}
+}
+
+func TestResolve_ReplicaExpansion(t *testing.T) {
+	ts, _ := Parse([]byte(exampleYAML))
+	agents := ts.Resolve()
+
+	// 1 eng-manager + 3 dev-workers + 1 product-manager = 5
+	if len(agents) != 5 {
+		t.Fatalf("resolved agents = %d, want 5", len(agents))
+	}
+
+	for i := 0; i < 3; i++ {
+		a := agents[1+i]
+		wantNum := i + 1
+		if a.ReplicaNum != wantNum {
+			t.Errorf("replica %d num = %d", wantNum, a.ReplicaNum)
+		}
+		if a.AgentName != "dev-worker" {
+			t.Errorf("replica %d agent = %q, want dev-worker", wantNum, a.AgentName)
+		}
+	}
+}
+
+func TestResolve_Labels(t *testing.T) {
+	ts, _ := Parse([]byte(exampleYAML))
+	agents := ts.Resolve()
+
+	labels := agents[0].Labels("platform-team")
+	if labels["team"] != "platform-team" {
+		t.Errorf("team label = %q", labels["team"])
+	}
+	if labels["agent"] != "eng-manager" {
+		t.Errorf("agent label = %q", labels["agent"])
+	}
+	if labels["role"] != "engineering-manager" {
+		t.Errorf("role label = %q", labels["role"])
+	}
+}
+
+func TestParseRAMMiB(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int
+	}{
+		{"4G", 4096},
+		{"6G", 6144},
+		{"2048M", 2048},
+		{"512m", 512},
+		{"2048", 2048},
+		{"", 0},
+	}
+	for _, tt := range tests {
+		got := ParseRAMMiB(tt.input)
+		if got != tt.want {
+			t.Errorf("ParseRAMMiB(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestResolve_CloneURLs(t *testing.T) {
+	ts, _ := Parse([]byte(exampleYAML))
+	agents := ts.Resolve()
+
+	urls := agents[0].CloneURLs()
+	if len(urls) != 1 {
+		t.Fatalf("clone urls = %d, want 1", len(urls))
+	}
+	if !strings.Contains(urls[0], "github.com/AndrewBudd/boxcutter") {
+		t.Errorf("clone url = %q", urls[0])
+	}
+}
+
+func TestResolve_Idempotent(t *testing.T) {
+	ts, _ := Parse([]byte(exampleYAML))
+	a1 := ts.Resolve()
+	a2 := ts.Resolve()
+	if len(a1) != len(a2) {
+		t.Fatalf("resolve not idempotent: %d vs %d", len(a1), len(a2))
+	}
+	for i := range a1 {
+		if a1[i].VMName != a2[i].VMName {
+			t.Errorf("resolve[%d] name mismatch: %q vs %q", i, a1[i].VMName, a2[i].VMName)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **Port YAML parser** to `orchestrator/internal/team/` with new fields: `Tapegun []string`, `RAMMiB()` converter, `CloneURLs()` builder, `Labels()` method
- **Add team SSH commands** to `orchestrator/internal/ssh/handler.go`:
  - `team apply -f -` — reads YAML from stdin, resolves defaults+replicas, creates VMs via existing `POST /api/vms`, idempotent (skips existing, destroys scale-down surplus highest-index-first)
  - `team destroy <name>` — finds VMs by team name prefix, destroys all
  - `team list` — groups VMs by team name prefix, shows count
  - `team status <name>` — tabular status of all team VMs
- **Add Labels to VM state** — `Labels map[string]string` on `state.VM`, `vmCreateRequest`, preserved across `SyncNodeVMs` refreshes
- **Add `ListVMsByLabel`** to state store for future label-based queries
- **Unit tests** for YAML parsing, validation, defaults, replica expansion, labels, RAM parsing, clone URLs

### Usage

```bash
# Apply a team spec
cat team.yaml | ssh orchestrator boxcutter team apply -f -

# List teams
ssh orchestrator boxcutter team list

# Team status
ssh orchestrator boxcutter team status platform-team

# Destroy a team
ssh orchestrator boxcutter team destroy platform-team
```

### Design decisions

- **Stdin-only for YAML** (`-f -`): file paths don't exist on the orchestrator VM, so only stdin piping is supported
- **Name-prefix matching** for team discovery: VMs are named `{team}-{agent}-{N}`, allowing team grouping without requiring labels to survive node syncs initially
- **Labels field** added to `state.VM` and propagated through create flow for future label-based queries (preserved across `SyncNodeVMs` refreshes)
- **Scale-down** destroys highest-indexed replicas first (e.g., shrinking replicas 5→3 removes -5 then -4)

## Test plan

- [ ] `go test ./orchestrator/internal/team/...` passes
- [ ] `cat team.yaml | ssh orch boxcutter team apply -f -` creates VMs with correct names
- [ ] Re-applying same YAML is a no-op (reports "ok" for existing VMs)
- [ ] `team destroy` removes all team VMs
- [ ] `team list` shows teams grouped by name prefix
- [ ] `team status` shows per-VM status
- [ ] Scale up (replicas 3→5) creates 2 new VMs
- [ ] Scale down (replicas 5→3) destroys highest-indexed VMs

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)