### PR TITLE
Feat #104: node agent accepts and forwards agent_config to vmid

### DIFF
--- a/node/agent/internal/vm/manager.go
+++ b/node/agent/internal/vm/manager.go
@@ -88,17 +88,18 @@ type ProgressFunc func(phase, message string)
 
 // CreateRequest is the API input for creating a VM.
 type CreateRequest struct {
-	Name             string   `json:"name"`
-	Type             string   `json:"type,omitempty"`        // "firecracker" (default) or "qemu"
-	Description      string   `json:"description,omitempty"` // user-provided description
-	VCPU             int      `json:"vcpu,omitempty"`
-	RAMMIB           int      `json:"ram_mib,omitempty"`
-	Disk             string   `json:"disk,omitempty"`
-	CloneURL         string   `json:"clone_url,omitempty"`
-	CloneURLs        []string `json:"clone_urls,omitempty"`
-	Mode             string   `json:"mode,omitempty"`
-	AuthorizedKeys   []string `json:"authorized_keys,omitempty"`
-	TailscaleAuthkey string   `json:"tailscale_authkey,omitempty"`
+	Name             string          `json:"name"`
+	Type             string          `json:"type,omitempty"`        // "firecracker" (default) or "qemu"
+	Description      string          `json:"description,omitempty"` // user-provided description
+	VCPU             int             `json:"vcpu,omitempty"`
+	RAMMIB           int             `json:"ram_mib,omitempty"`
+	Disk             string          `json:"disk,omitempty"`
+	CloneURL         string          `json:"clone_url,omitempty"`
+	CloneURLs        []string        `json:"clone_urls,omitempty"`
+	Mode             string          `json:"mode,omitempty"`
+	AuthorizedKeys   []string        `json:"authorized_keys,omitempty"`
+	TailscaleAuthkey string          `json:"tailscale_authkey,omitempty"`
+	AgentConfig      json.RawMessage `json:"agent_config,omitempty"`
 
 	progressFn ProgressFunc `json:"-"`
 }
@@ -229,6 +230,7 @@ func (m *Manager) createSetup(req *CreateRequest) (*VMState, error) {
 			GitHubRepos:      githubRepos,
 			GoldenVer:        goldenVer,
 			TailscaleAuthkey: req.TailscaleAuthkey,
+			AgentConfig:      req.AgentConfig,
 		}
 		if err := SaveVMState(vmDir, st); err != nil {
 			os.RemoveAll(vmDir)
@@ -407,6 +409,7 @@ func (m *Manager) postStartVM(st *VMState, resp *CreateResponse, progress Progre
 			Mode:        st.Mode,
 			GitHubRepo:  st.GitHubRepo,
 			GitHubRepos: st.AllGitHubRepos(),
+			AgentConfig: st.AgentConfig,
 		})
 	}
 
@@ -1375,6 +1378,7 @@ func (m *Manager) registerWithVMID(st *VMState) {
 		Mode:        st.Mode,
 		GitHubRepo:  st.GitHubRepo,
 		GitHubRepos: st.AllGitHubRepos(),
+		AgentConfig: st.AgentConfig,
 	})
 }
 
@@ -1400,6 +1404,7 @@ func (m *Manager) EnsureVMIDRegistered(name string) error {
 		Mode:        st.Mode,
 		GitHubRepo:  st.GitHubRepo,
 		GitHubRepos: st.AllGitHubRepos(),
+		AgentConfig: st.AgentConfig,
 	})
 }
 
@@ -3356,6 +3361,7 @@ func (m *Manager) FinalizeMigration(name string) error {
 			Mode:        st.Mode,
 			GitHubRepo:  st.GitHubRepo,
 			GitHubRepos: st.AllGitHubRepos(),
+			AgentConfig: st.AgentConfig,
 		})
 		log.Printf("FinalizeMigration: registered %s with vmid (mark=%d)", name, st.Mark)
 	}
@@ -3497,6 +3503,7 @@ func (m *Manager) ImportQEMUState(name, statePath string) (*CreateResponse, erro
 			Mode:        st.Mode,
 			GitHubRepo:  st.GitHubRepo,
 			GitHubRepos: st.AllGitHubRepos(),
+			AgentConfig: st.AgentConfig,
 		})
 		// Import mailbox after registration
 		m.importMailboxFromFile(st.Name, VMDir(st.Name))
@@ -3733,6 +3740,7 @@ func (m *Manager) ImportSnapshot(st *VMState) (*CreateResponse, error) {
 			Mode:        st.Mode,
 			GitHubRepo:  st.GitHubRepo,
 			GitHubRepos: st.AllGitHubRepos(),
+			AgentConfig: st.AgentConfig,
 		})
 		// Import mailbox after registration
 		m.importMailboxFromFile(st.Name, VMDir(st.Name))

--- a/node/agent/internal/vm/state.go
+++ b/node/agent/internal/vm/state.go
@@ -27,9 +27,10 @@ type VMState struct {
 	GitHubRepo  string   `json:"github_repo,omitempty"`  // backwards compat — single repo
 	GitHubRepos    []string `json:"github_repos,omitempty"`    // all GitHub repos (owner/repo)
 	GitHubProjects []string `json:"github_projects,omitempty"` // GitHub projects (owner/number)
-	TailscaleIP      string `json:"tailscale_ip,omitempty"`
-	TailscaleAuthkey string `json:"tailscale_authkey,omitempty"`
-	GoldenVer        string `json:"golden_version,omitempty"`
+	TailscaleIP      string          `json:"tailscale_ip,omitempty"`
+	TailscaleAuthkey string          `json:"tailscale_authkey,omitempty"`
+	GoldenVer        string          `json:"golden_version,omitempty"`
+	AgentConfig      json.RawMessage `json:"agent_config,omitempty"` // opaque JSON blob forwarded to vmid
 }
 
 // AllGitHubRepos returns the list of GitHub repos, falling back to the single

--- a/node/agent/internal/vmid/client.go
+++ b/node/agent/internal/vmid/client.go
@@ -29,13 +29,14 @@ func NewClient(socketPath string) *Client {
 }
 
 type RegisterRequest struct {
-	VMID        string   `json:"vm_id"`
-	VMType      string   `json:"vm_type,omitempty"` // "firecracker" or "qemu"
-	IP          string   `json:"ip"`
-	Mark        int      `json:"mark"`
-	Mode        string   `json:"mode"`
-	GitHubRepo  string   `json:"github_repo,omitempty"`
-	GitHubRepos []string `json:"github_repos,omitempty"`
+	VMID        string          `json:"vm_id"`
+	VMType      string          `json:"vm_type,omitempty"` // "firecracker" or "qemu"
+	IP          string          `json:"ip"`
+	Mark        int             `json:"mark"`
+	Mode        string          `json:"mode"`
+	GitHubRepo  string          `json:"github_repo,omitempty"`
+	GitHubRepos []string        `json:"github_repos,omitempty"`
+	AgentConfig json.RawMessage `json:"agent_config,omitempty"`
 }
 
 type ReposResponse struct {

--- a/node/vmid/internal/api/admin.go
+++ b/node/vmid/internal/api/admin.go
@@ -89,6 +89,24 @@ func (h *AdminHandler) handleRegister(w http.ResponseWriter, r *http.Request) {
 		GitHubRepos: req.GitHubRepos,
 		AgentConfig: req.AgentConfig,
 	}
+
+	// Merge labels from agent_config into VM labels
+	if len(req.AgentConfig) > 0 {
+		var ac struct {
+			Labels map[string]string `json:"labels"`
+		}
+		if json.Unmarshal(req.AgentConfig, &ac) == nil && len(ac.Labels) > 0 {
+			if rec.Labels == nil {
+				rec.Labels = make(map[string]string)
+			}
+			for k, v := range ac.Labels {
+				if _, exists := rec.Labels[k]; !exists {
+					rec.Labels[k] = v
+				}
+			}
+		}
+	}
+
 	h.reg.Register(rec)
 
 	w.WriteHeader(http.StatusCreated)

--- a/orchestrator/internal/ssh/handler.go
+++ b/orchestrator/internal/ssh/handler.go
@@ -210,6 +210,14 @@ func (h *Handler) cmdNew(args []string) int {
 				body["tailscale_authkey"] = args[i+1]
 				i++
 			}
+		case "--agent-config":
+			if i+1 < len(args) {
+				var raw json.RawMessage
+				if err := json.Unmarshal([]byte(args[i+1]), &raw); err == nil {
+					body["agent_config"] = raw
+				}
+				i++
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Add `agent_config` (`json.RawMessage`) to the node agent's `CreateRequest`, `VMState`, and vmid `RegisterRequest` — config flows opaquely from orchestrator → node agent → vmid
- Merge `labels` from `agent_config` into VM labels on vmid registration (explicit labels take precedence)
- Add `--agent-config` flag to orchestrator's `cmdNew` SSH command (plumbing for `team apply` in #105)
- All 7 vmid Register call sites (create, re-register, migration finalize) forward `agent_config` from persisted state

## Files changed

- `node/agent/internal/vm/manager.go` — `AgentConfig` on `CreateRequest`, forwarded through all Register calls
- `node/agent/internal/vm/state.go` — `AgentConfig` on `VMState` (persisted in vm.json)
- `node/agent/internal/vmid/client.go` — `AgentConfig` on `RegisterRequest`
- `node/vmid/internal/api/admin.go` — accept `agent_config`, extract and merge labels
- `node/vmid/internal/registry/registry.go` — `AgentConfig` on `VMRecord`
- `orchestrator/internal/ssh/handler.go` — `--agent-config` flag on `cmdNew`

## Test plan

- [x] `go build ./...` passes for node/agent, node/vmid, orchestrator
- [x] `go test ./...` passes for node/vmid (only module with unit tests)
- [ ] Integration: create VM with `agent_config` → verify vmid registration includes it
- [ ] Integration: create VM without `agent_config` → backwards compatible
- [ ] Integration: verify labels from `agent_config` merged into VM labels

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)