### PR TITLE
Fix #106: include tapegun-guest plugin in tools.img

### DIFF
--- a/host/build-image.sh
+++ b/host/build-image.sh
@@ -132,6 +132,11 @@ if [ "$VM_TYPE" = "node" ]; then
   cp "${REPO_DIR}/node/golden/config/boxcutter-tapegun" "${TOOLS_STAGE}/bin/boxcutter-tapegun"
   chmod 755 "${TOOLS_STAGE}/bin/boxcutter-tapegun"
   cp "${REPO_DIR}/node/golden/config/boxcutter-tapegun.service" "${TOOLS_STAGE}/etc/systemd/boxcutter-tapegun.service"
+  if [ -d "${REPO_DIR}/plugins/tapegun-guest" ]; then
+    mkdir -p "${TOOLS_STAGE}/plugins"
+    cp -r "${REPO_DIR}/plugins/tapegun-guest" "${TOOLS_STAGE}/plugins/tapegun-guest"
+    echo "  tapegun-guest plugin included"
+  fi
   mksquashfs "${TOOLS_STAGE}" "${BUILD_DIR}/tools.img" -noappend -comp gzip -quiet
   echo "  tools.img: $(du -h "${BUILD_DIR}/tools.img" | cut -f1)"
 else

--- a/host/provision.sh
+++ b/host/provision.sh
@@ -153,6 +153,11 @@ build_node() {
   cp "${REPO_DIR}/node/golden/config/boxcutter-tapegun" "${TOOLS_STAGE}/bin/boxcutter-tapegun"
   chmod 755 "${TOOLS_STAGE}/bin/boxcutter-tapegun"
   cp "${REPO_DIR}/node/golden/config/boxcutter-tapegun.service" "${TOOLS_STAGE}/etc/systemd/boxcutter-tapegun.service"
+  if [ -d "${REPO_DIR}/plugins/tapegun-guest" ]; then
+    mkdir -p "${TOOLS_STAGE}/plugins"
+    cp -r "${REPO_DIR}/plugins/tapegun-guest" "${TOOLS_STAGE}/plugins/tapegun-guest"
+    echo "  tapegun-guest plugin included"
+  fi
   mksquashfs "${TOOLS_STAGE}" "${BUILD_DIR}/tools.img" -noappend -comp gzip -quiet
   echo "  tools.img: $(du -h "${BUILD_DIR}/tools.img" | cut -f1)"
 


### PR DESCRIPTION
## Summary

- Add `plugins/tapegun-guest/` to the tools.img squashfs build in both `host/provision.sh` and `host/build-image.sh`
- Plugin ships at `/opt/boxcutter/tools/plugins/tapegun-guest/` inside VMs
- Tapegun can install it on every boot without depending on golden image rebuild

### tools.img layout (after)

```
tools.img (squashfs, mounted at /opt/boxcutter/tools)
├── bin/
│   ├── boxcutter
│   └── boxcutter-tapegun
├── etc/systemd/
│   └── boxcutter-tapegun.service
└── plugins/                          ← NEW
    └── tapegun-guest/
        ├── .claude-plugin/plugin.json
        ├── hooks/{hooks.json, check-inbox.sh, report-status.sh}
        └── skills/receiving-messages/SKILL.md
```

## Test plan

- [ ] Build tools.img via provision.sh — verify `plugins/tapegun-guest/` present
- [ ] Build tools.img via build-image.sh — same verification
- [ ] Existing contents (boxcutter CLI, tapegun daemon, service unit) unchanged

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)