### PR TITLE
Fix #106: include tapegun-guest plugin in tools.img

### DIFF
--- a/host/build-image.sh
+++ b/host/build-image.sh
@@ -132,6 +132,11 @@ if [ "$VM_TYPE" = "node" ]; then
   cp "${REPO_DIR}/node/golden/config/boxcutter-tapegun" "${TOOLS_STAGE}/bin/boxcutter-tapegun"
   chmod 755 "${TOOLS_STAGE}/bin/boxcutter-tapegun"
   cp "${REPO_DIR}/node/golden/config/boxcutter-tapegun.service" "${TOOLS_STAGE}/etc/systemd/boxcutter-tapegun.service"
+  # Include tapegun-guest plugin so updates ship via tools.img (no golden rebuild)
+  if [ -d "${REPO_DIR}/plugins/tapegun-guest" ]; then
+    mkdir -p "${TOOLS_STAGE}/plugins"
+    cp -r "${REPO_DIR}/plugins/tapegun-guest" "${TOOLS_STAGE}/plugins/tapegun-guest"
+  fi
   mksquashfs "${TOOLS_STAGE}" "${BUILD_DIR}/tools.img" -noappend -comp gzip -quiet
   echo "  tools.img: $(du -h "${BUILD_DIR}/tools.img" | cut -f1)"
 else

--- a/host/provision.sh
+++ b/host/provision.sh
@@ -153,6 +153,11 @@ build_node() {
   cp "${REPO_DIR}/node/golden/config/boxcutter-tapegun" "${TOOLS_STAGE}/bin/boxcutter-tapegun"
   chmod 755 "${TOOLS_STAGE}/bin/boxcutter-tapegun"
   cp "${REPO_DIR}/node/golden/config/boxcutter-tapegun.service" "${TOOLS_STAGE}/etc/systemd/boxcutter-tapegun.service"
+  # Include tapegun-guest plugin so updates ship via tools.img (no golden rebuild)
+  if [ -d "${REPO_DIR}/plugins/tapegun-guest" ]; then
+    mkdir -p "${TOOLS_STAGE}/plugins"
+    cp -r "${REPO_DIR}/plugins/tapegun-guest" "${TOOLS_STAGE}/plugins/tapegun-guest"
+  fi
   mksquashfs "${TOOLS_STAGE}" "${BUILD_DIR}/tools.img" -noappend -comp gzip -quiet
   echo "  tools.img: $(du -h "${BUILD_DIR}/tools.img" | cut -f1)"
 

--- a/node/golden/config/boxcutter-tapegun
+++ b/node/golden/config/boxcutter-tapegun
@@ -307,13 +307,16 @@ EOSETTINGS
 
         # Install tapegun-guest plugin so inbox, stop notifications, and
         # status reporting hooks are active in the Claude Code session.
+        # Prefer tools.img copy (updated without golden rebuild) over baked-in copy.
+        PLUGIN_SRC="/opt/boxcutter/tools/plugins/tapegun-guest"
         PLUGIN_DIR="$HOME/.claude/plugins/tapegun-guest"
-        if [ -d "$PLUGIN_DIR" ]; then
-            tmux send-keys -t main "claude plugin install $PLUGIN_DIR 2>/dev/null" Enter
-            sleep 2
-            echo "tapegun: installed tapegun-guest plugin"
-        else
-            echo "tapegun: WARNING: plugin not found at $PLUGIN_DIR"
+        if [ -d "$PLUGIN_SRC" ]; then
+            mkdir -p "$HOME/.claude/plugins"
+            rm -rf "$PLUGIN_DIR"
+            cp -r "$PLUGIN_SRC" "$PLUGIN_DIR"
+            echo "tapegun: installed tapegun-guest plugin from tools.img"
+        elif [ ! -d "$PLUGIN_DIR" ]; then
+            echo "tapegun: WARNING: plugin not found at $PLUGIN_SRC or $PLUGIN_DIR"
         fi
 
         # Start Claude Code


### PR DESCRIPTION
## Summary
- Add `plugins/tapegun-guest/` directory to tools.img in both build paths (`provision.sh` and `build-image.sh`)
- Update tapegun to copy plugin from `/opt/boxcutter/tools/plugins/tapegun-guest/` (tools.img) on each boot, preferring it over the baked-in golden image copy
- Uses direct file copy instead of `claude plugin install` to avoid interactive prompts

This allows plugin updates to ship via tools.img without requiring a golden image rebuild.

Closes #106. Part of #94.

## Test plan
- [x] 49 tapegun shell tests pass
- [ ] Build tools.img → verify `plugins/tapegun-guest/` is present in squashfs
- [ ] Boot VM with new tools.img → verify plugin appears at `/opt/boxcutter/tools/plugins/tapegun-guest/`
- [ ] Tapegun copies plugin to `~/.claude/plugins/tapegun-guest/` on startup
- [ ] Existing tools.img contents (boxcutter CLI, tapegun script) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)