### PR TITLE
Add crash detection and auto-restart to tapegun daemon

### DIFF
--- a/node/golden/config/boxcutter-tapegun
+++ b/node/golden/config/boxcutter-tapegun
@@ -469,5 +469,35 @@ print(json.dumps({'pane_content': sys.stdin.read(), 'status': '$STATUS'}))" <<< 
         fi
     fi
 
+    # --- Crash detection & auto-restart ---
+    # If autostart is enabled, ensure tmux session and Claude Code stay alive.
+    if [ "$AUTOSTART_CLAUDE" = "true" ]; then
+        if ! $TMUX_CMD has-session -t main 2>/dev/null; then
+            # Session gone entirely — recreate and relaunch
+            echo "tapegun: tmux session 'main' gone, restarting"
+            $TMUX_CMD new-session -d -s main
+            sleep 1
+            $TMUX_CMD send-keys -t main 'export PATH="$HOME/.local/bin:$HOME/.local/share/mise/shims:$PATH"' Enter
+            sleep 0.5
+            if [ -n "$CLAUDE_WORKING_DIR" ] && [ -d "$CLAUDE_WORKING_DIR" ]; then
+                $TMUX_CMD send-keys -t main "cd $CLAUDE_WORKING_DIR" Enter
+                sleep 0.5
+            fi
+            CLAUDE_CMD="claude"
+            [ -n "$CLAUDE_FLAGS" ] && CLAUDE_CMD="$CLAUDE_CMD $CLAUDE_FLAGS"
+            [ "$CLAUDE_RESUME" = "true" ] && CLAUDE_CMD="$CLAUDE_CMD --resume"
+            $TMUX_CMD send-keys -t main "$CLAUDE_CMD" Enter
+            echo "tapegun: Claude Code restarted (session recreated)"
+        elif ! pgrep -f 'claude' -u "$(id -u)" >/dev/null 2>&1; then
+            # Session exists but Claude Code process died — relaunch in existing session
+            echo "tapegun: Claude Code process not found, restarting"
+            CLAUDE_CMD="claude"
+            [ -n "$CLAUDE_FLAGS" ] && CLAUDE_CMD="$CLAUDE_CMD $CLAUDE_FLAGS"
+            [ "$CLAUDE_RESUME" = "true" ] && CLAUDE_CMD="$CLAUDE_CMD --resume"
+            $TMUX_CMD send-keys -t main "$CLAUDE_CMD" Enter
+            echo "tapegun: Claude Code restarted (in existing session)"
+        fi
+    fi
+
     sleep "$POLL_INTERVAL"
 done


### PR DESCRIPTION
## Summary

Add crash detection and auto-restart logic to the tapegun monitoring loop (`node/golden/config/boxcutter-tapegun`). Every poll cycle (5s), tapegun now checks if Claude Code is still alive and restarts it if needed.

### Failure modes handled

| Failure | Detection | Recovery |
|---------|-----------|----------|
| tmux session `main` gone | `tmux has-session -t main` fails | Recreate session, set PATH + working dir, relaunch Claude Code |
| Claude Code process died | `pgrep -f 'claude' -u $(id -u)` finds nothing | Relaunch in existing tmux session |

### Behavior

- Only active when `AUTOSTART_CLAUDE=true` (the default)
- Uses `--resume` flag when `CLAUDE_RESUME=true` to continue previous conversation
- Preserves existing `CLAUDE_FLAGS` and `CLAUDE_WORKING_DIR`
- Logs restart events for visibility

### Loop position

The check runs after activity posting and inbox processing, before `sleep $POLL_INTERVAL`:

```
while true:
  post health
  post activity
  check inbox
  → crash detection & restart  ← NEW
  sleep 5
```

## Test plan

- [ ] Kill Claude Code process (`pkill claude`) → tapegun restarts it within 5s
- [ ] Kill tmux session (`tmux kill-session -t main`) → tapegun recreates session + relaunches
- [ ] With `AUTOSTART_CLAUDE=false` → no restart attempts
- [ ] Normal operation (Claude running) → no-op, no log spam

🤖 Generated with [Claude Code](https://claude.com/claude-code)