### PR TITLE
Fix #128: orphan detection skips upgrade replacement nodes during drain

### DIFF
--- a/host/cmd/host/main.go
+++ b/host/cmd/host/main.go
@@ -3645,6 +3645,28 @@ func cleanupOrphanNodes(cfg HostConfig, state *cluster.State) []string {
 	var cleaned []string
 	nodeClient := &http.Client{Timeout: 5 * time.Second}
 
+	// Issue #128: Never remove nodes that are part of an active upgrade.
+	// During rolling upgrades, the replacement node has 0 VMs while
+	// migrations are in-flight — killing it would abort the drain.
+	upgradeProtected := make(map[string]bool)
+	if g := state.UpgradeGoal; g != nil {
+		if g.DrainTargetNodeID != "" {
+			upgradeProtected[g.DrainTargetNodeID] = true
+		}
+		if g.DeployedNodeID != "" {
+			upgradeProtected[g.DeployedNodeID] = true
+		}
+	}
+	// Also protect any node that is an active drain target: if any node
+	// has status "draining", migrations may be landing on another node.
+	hasDrainingNode := false
+	for _, n := range state.Nodes {
+		if n.Status == "draining" {
+			hasDrainingNode = true
+			break
+		}
+	}
+
 	// Count how many nodes have VMs — we need at least one node with VMs
 	// If no VMs exist at all, keep the first active node
 	nodesWithVMs := 0
@@ -3670,6 +3692,20 @@ func cleanupOrphanNodes(cfg HostConfig, state *cluster.State) []string {
 		// Keep at least one node
 		if len(state.Nodes)-len(cleaned) <= 1 {
 			break
+		}
+
+		// Issue #128: skip nodes protected by upgrade goal
+		if upgradeProtected[n.ID] {
+			log.Printf("Skipping orphan cleanup of %s: node is upgrade drain target", n.ID)
+			continue
+		}
+
+		// Issue #128: if a drain is in progress, don't remove any node
+		// with 0 VMs — it may be the migration target even if not
+		// explicitly tracked in DrainTargetNodeID (e.g. manual drain).
+		if hasDrainingNode && n.IsActive() {
+			log.Printf("Skipping orphan cleanup of %s: drain in progress on another node", n.ID)
+			continue
 		}
 
 		// Check if this node has VMs

--- a/host/cmd/host/upgrade_test.go
+++ b/host/cmd/host/upgrade_test.go
@@ -998,6 +998,167 @@ func TestUpgrade_InsufficientMemoryGoalPreservedVsAutoAbortGoalCleared(t *testin
 	}
 }
 
+// --- Issue #128: orphan detection vs upgrade replacement nodes ---
+
+func TestCleanupOrphanNodes_SkipsDrainTarget(t *testing.T) {
+	// During an upgrade, the replacement node (DrainTargetNodeID) has 0 VMs
+	// because migrations are in-flight. cleanupOrphanNodes must NOT remove it.
+	path := filepath.Join(t.TempDir(), "cluster.json")
+	state := &cluster.State{}
+	state.SetPath(path)
+	state.Nodes = []cluster.VMEntry{
+		{ID: "node-1", Status: "draining", BridgeIP: "192.168.50.3", ImageDigest: "sha256:old"},
+		{ID: "node-2", Status: "active", BridgeIP: "192.168.50.4", ImageDigest: "sha256:new"},
+	}
+	state.SetUpgradeGoal(&cluster.UpgradeGoal{
+		VMType:            "node",
+		Tag:               "v2",
+		DrainTargetNodeID: "node-2",
+		NodeImage:         &cluster.ImageRef{Digest: "sha256:new"},
+	})
+	state.Save()
+
+	cfg := HostConfig{}
+	cleaned := cleanupOrphanNodes(cfg, state)
+
+	// node-2 must survive — it's the drain target
+	if containsStr(cleaned, "node-2") {
+		t.Fatal("node-2 (drain target) was removed — this is the #128 bug")
+	}
+	found := false
+	for _, n := range state.Nodes {
+		if n.ID == "node-2" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("node-2 should still be in state after cleanup")
+	}
+}
+
+func TestCleanupOrphanNodes_SkipsDeployedNode(t *testing.T) {
+	// The DeployedNodeID is the replacement node that received the latest
+	// agent binary but hasn't started receiving VMs yet.
+	path := filepath.Join(t.TempDir(), "cluster.json")
+	state := &cluster.State{}
+	state.SetPath(path)
+	state.Nodes = []cluster.VMEntry{
+		{ID: "node-1", Status: "active", BridgeIP: "192.168.50.3", ImageDigest: "sha256:old"},
+		{ID: "node-2", Status: "active", BridgeIP: "192.168.50.4", ImageDigest: "sha256:new"},
+	}
+	state.SetUpgradeGoal(&cluster.UpgradeGoal{
+		VMType:         "node",
+		Tag:            "v2",
+		DeployedNodeID: "node-2",
+		NodeImage:      &cluster.ImageRef{Digest: "sha256:new"},
+	})
+	state.Save()
+
+	cfg := HostConfig{}
+	cleaned := cleanupOrphanNodes(cfg, state)
+
+	if containsStr(cleaned, "node-2") {
+		t.Fatal("node-2 (deployed replacement) was removed — should be protected")
+	}
+}
+
+func TestCleanupOrphanNodes_SkipsActiveNodesDuringDrain(t *testing.T) {
+	// When any node has status "draining", active nodes with 0 VMs should
+	// be protected — they may be the drain target even without explicit
+	// DrainTargetNodeID (e.g. manual drain, or non-upgrade drain).
+	path := filepath.Join(t.TempDir(), "cluster.json")
+	state := &cluster.State{}
+	state.SetPath(path)
+	state.Nodes = []cluster.VMEntry{
+		{ID: "node-1", Status: "draining", BridgeIP: "192.168.50.3"},
+		{ID: "node-2", Status: "active", BridgeIP: "192.168.50.4"},
+		{ID: "node-3", Status: "active", BridgeIP: "192.168.50.5"},
+	}
+	state.Save()
+
+	cfg := HostConfig{}
+	cleaned := cleanupOrphanNodes(cfg, state)
+
+	// Neither active node should be removed while a drain is in progress
+	if containsStr(cleaned, "node-2") || containsStr(cleaned, "node-3") {
+		t.Fatalf("active nodes removed during drain: %v", cleaned)
+	}
+}
+
+func TestCleanupOrphanNodes_RemovesWhenNoUpgrade(t *testing.T) {
+	// Without an upgrade goal or draining node, orphan nodes with 0 VMs
+	// should still be cleaned up normally.
+	path := filepath.Join(t.TempDir(), "cluster.json")
+	state := &cluster.State{}
+	state.SetPath(path)
+	state.Nodes = []cluster.VMEntry{
+		{ID: "node-1", Status: "active", BridgeIP: "192.168.50.3"},
+		{ID: "node-2", Status: "active", BridgeIP: "192.168.50.4"},
+		{ID: "node-3", Status: "active", BridgeIP: "192.168.50.5"},
+	}
+	state.Save()
+
+	cfg := HostConfig{}
+	cleaned := cleanupOrphanNodes(cfg, state)
+
+	// With no upgrade, no drain, and PID=0 (not running), nodes with 0 VMs
+	// should be cleaned up (keeping at least 1)
+	if len(cleaned) == 0 {
+		t.Fatal("expected some orphan nodes to be cleaned up when no upgrade is active")
+	}
+	if len(state.Nodes) < 1 {
+		t.Fatal("should always keep at least 1 node")
+	}
+}
+
+func TestCleanupOrphanNodes_UpgradeCancelDuringDrain(t *testing.T) {
+	// Reproduces issue #128: upgrade-cancel fires cleanupOrphanNodes while
+	// drainNode is running on a separate goroutine. The replacement node
+	// (DrainTargetNodeID) has 0 VMs because migrations are in-flight.
+	path := filepath.Join(t.TempDir(), "cluster.json")
+	state := &cluster.State{}
+	state.SetPath(path)
+	state.Nodes = []cluster.VMEntry{
+		{ID: "old-node", Status: "draining", BridgeIP: "192.168.50.3", ImageDigest: "sha256:old"},
+		{ID: "new-node", Status: "active", BridgeIP: "192.168.50.4", ImageDigest: "sha256:new"},
+	}
+	state.SetUpgradeGoal(&cluster.UpgradeGoal{
+		VMType:            "node",
+		Tag:               "v2",
+		DrainTargetNodeID: "new-node",
+		DeployedNodeID:    "new-node",
+		NodeImage:         &cluster.ImageRef{Digest: "sha256:new"},
+	})
+	state.Save()
+
+	cfg := HostConfig{}
+	cleaned := cleanupOrphanNodes(cfg, state)
+
+	// The replacement node MUST survive — this is the #128 fix
+	if containsStr(cleaned, "new-node") {
+		t.Fatal("REGRESSION #128: replacement node killed during upgrade drain")
+	}
+	// new-node must still be in state
+	found := false
+	for _, n := range state.Nodes {
+		if n.ID == "new-node" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("new-node (replacement) should still be in state")
+	}
+}
+
+func containsStr(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
 // SetPath sets the path for state persistence (for testing)
 func init() {
 	// Ensure the cluster package has helper methods we need


### PR DESCRIPTION
## Summary

- Fixes race condition where `cleanupOrphanNodes()` killed the upgrade replacement node while VM migrations were in-flight from the old node
- The replacement node had 0 VMs (migrations hadn't landed yet) so orphan detection treated it as an orphan and stopped it
- Root cause: `POST /upgrade/cancel` handler calls `cleanupOrphanNodes()` after a 10s timeout, but `drainNode()` on the reconciler goroutine can take minutes — so they run concurrently

## Changes

**`host/cmd/host/main.go`** — `cleanupOrphanNodes()` now checks upgrade goal state before removing nodes:
- Skips nodes that are the `DrainTargetNodeID` (the replacement node receiving migrations)
- Skips nodes that are the `DeployedNodeID` (replacement with latest binary, pre-drain)
- Skips all active nodes when any node has status `"draining"` (migrations may be in-flight to them)

**`host/cmd/host/upgrade_test.go`** — 5 new tests:
- `TestCleanupOrphanNodes_SkipsDrainTarget` — drain target protected during upgrade
- `TestCleanupOrphanNodes_SkipsDeployedNode` — deployed replacement protected
- `TestCleanupOrphanNodes_SkipsActiveNodesDuringDrain` — all active nodes protected during any drain
- `TestCleanupOrphanNodes_RemovesWhenNoUpgrade` — normal cleanup still works without upgrade
- `TestCleanupOrphanNodes_UpgradeCancelDuringDrain` — reproduces exact #128 scenario

## Test plan

- [x] All 5 new unit tests pass (`go test ./cmd/host/ -run TestCleanupOrphanNodes -v`)
- [x] Full host test suite passes (`cd host && go test ./...`)
- [x] Binary builds cleanly
- [ ] Live cluster e2e: trigger upgrade, cancel mid-drain, verify replacement node survives

## Evidence from #128

```
18:54:57 Drain: migrating 2 VMs from dev-node-2 to dev-node-3
19:01:23 Stopping orphan node dev-node-3 (PID 100241, 0 VMs)   <-- BUG
19:01:25 Resetting node dev-node-2 from 'draining' to 'active'
19:01:39 Drain: drain-vm-1 migration failed
```

With this fix, node-3 would be skipped: `"Skipping orphan cleanup of dev-node-3: node is upgrade drain target"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)