### PR TITLE
Fix #135, #138: reconcile from reality, nodes as source of truth

### DIFF
--- a/host/cmd/host/main.go
+++ b/host/cmd/host/main.go
@@ -459,32 +459,6 @@ func runDaemon() {
 	}
 }
 
-// reconcileTrackedPIDs verifies that PIDs in cluster state still belong to the
-// expected QEMU processes. After a host restart or binary upgrade, a saved PID
-// may no longer exist or may have been reused by an unrelated process. Clear
-// stale PIDs so bootRecover will relaunch VMs from disk rather than skipping
-// them as "already running".
-func reconcileTrackedPIDs(state *cluster.State) {
-	changed := false
-	if state.Orchestrator != nil && state.Orchestrator.PID > 0 {
-		if !isQEMUProcess(state.Orchestrator.PID) {
-			log.Printf("  orchestrator PID %d is stale (not a QEMU process), clearing for relaunch", state.Orchestrator.PID)
-			state.SetPID(state.Orchestrator.ID, 0)
-			changed = true
-		}
-	}
-	for _, node := range state.Nodes {
-		if node.PID > 0 && !isQEMUProcess(node.PID) {
-			log.Printf("  %s PID %d is stale (not a QEMU process), clearing for relaunch", node.ID, node.PID)
-			state.SetPID(node.ID, 0)
-			changed = true
-		}
-	}
-	if changed {
-		state.Save()
-	}
-}
-
 // isQEMUProcess checks whether the given PID is a running qemu-system process
 // by inspecting /proc/<pid>/cmdline. Returns false if the process doesn't exist
 // or is not QEMU.
@@ -497,26 +471,16 @@ func isQEMUProcess(pid int) bool {
 	return len(args) > 0 && strings.HasSuffix(args[0], "qemu-system-x86_64")
 }
 
-// discoverOrphanedVMs scans /proc for running qemu-system-x86_64 processes
-// that are not tracked in the cluster state. This handles the case where
-// cluster.json was lost or corrupted but VMs are still running.
-func discoverOrphanedVMs(cfg HostConfig, state *cluster.State) {
+// scanRunningVMs scans /proc for all running qemu-system-x86_64 processes
+// and returns VMEntry structs parsed from their command lines. This is the
+// ground truth — what is actually running on the host right now.
+func scanRunningVMs(cfg HostConfig) (orch *cluster.VMEntry, nodes []cluster.VMEntry) {
 	entries, err := os.ReadDir("/proc")
 	if err != nil {
-		log.Printf("WARNING: cannot scan /proc: %v", err)
-		return
+		log.Printf("WARNING: cannot scan /proc for running VMs: %v", err)
+		return nil, nil
 	}
 
-	// Build set of PIDs already tracked
-	knownPIDs := map[int]bool{}
-	if state.Orchestrator != nil {
-		knownPIDs[state.Orchestrator.PID] = true
-	}
-	for _, n := range state.Nodes {
-		knownPIDs[n.PID] = true
-	}
-
-	discovered := 0
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -525,11 +489,7 @@ func discoverOrphanedVMs(cfg HostConfig, state *cluster.State) {
 		if err != nil || pid <= 0 {
 			continue
 		}
-		if knownPIDs[pid] {
-			continue
-		}
 
-		// Read cmdline
 		cmdline, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
 		if err != nil {
 			continue
@@ -539,44 +499,136 @@ func discoverOrphanedVMs(cfg HostConfig, state *cluster.State) {
 			continue
 		}
 
-		// Parse QEMU args to extract VM identity
 		vmEntry := parseQEMUArgs(args, pid, cfg)
 		if vmEntry == nil {
 			continue
 		}
 
 		if vmEntry.Type == "orchestrator" {
-			if state.Orchestrator != nil && qemu.IsRunning(state.Orchestrator.PID) {
-				continue // already have a running orchestrator
+			if orch != nil {
+				log.Printf("WARNING: multiple orchestrator QEMU processes found (PID %d and %d)", orch.PID, pid)
+				continue
 			}
-			log.Printf("  Discovered orphaned orchestrator (PID %d, disk %s) — recovering", pid, vmEntry.Disk)
-			state.SetOrchestrator(*vmEntry)
-			discovered++
+			orch = vmEntry
 		} else if vmEntry.Type == "node" {
-			existing := state.GetNode(vmEntry.ID)
-			if existing != nil && qemu.IsRunning(existing.PID) {
-				continue // already tracked and running
-			}
-			if existing != nil {
-				// Entry exists but PID changed — update it
-				log.Printf("  Discovered orphaned node %s (PID %d, disk %s) — recovering", vmEntry.ID, pid, vmEntry.Disk)
-			} else {
-				// Unknown QEMU process not in cluster state — adopt it.
-				// These are likely live nodes whose state wasn't persisted
-				// (e.g. upgrade reconciler updated in-memory state but
-				// crashed before flushing cluster.json). Killing them would
-				// destroy any VMs running on the node. See issue #85.
-				log.Printf("  Found unknown QEMU node %s (PID %d, disk %s) not in cluster state — adopting", vmEntry.ID, pid, vmEntry.Disk)
-			}
-			state.AddNode(*vmEntry)
-			discovered++
+			nodes = append(nodes, *vmEntry)
+		}
+	}
+	return orch, nodes
+}
+
+// reconcileFromReality builds cluster state from running QEMU processes (the
+// ground truth), then merges in metadata from cluster.json that cannot be
+// derived from process inspection (UpgradeGoal, image versions/digests,
+// drain status). This implements the principle from issue #135: "Reality is
+// the source of truth. cluster.json is a cache."
+//
+// The merge rules:
+//   - A running QEMU process is ALWAYS adopted into state, even if cluster.json
+//     has no entry for it. Never kill a VM because it's not in the file.
+//   - A cluster.json entry with no running QEMU process is removed (stale),
+//     UNLESS its status is "draining"/"upgrading" and the disk still exists
+//     (the VM may be intentionally stopped during an upgrade cycle).
+//   - For entries that exist in both reality and cluster.json, reality wins for
+//     PID/TAP/MAC/RAM/VCPU; cluster.json wins for image metadata and status.
+func reconcileFromReality(cfg HostConfig, state *cluster.State) {
+	log.Println("Reconciling state from running QEMU processes...")
+
+	realOrch, realNodes := scanRunningVMs(cfg)
+
+	// Build lookup of real nodes by ID
+	realNodeMap := make(map[string]*cluster.VMEntry)
+	for i := range realNodes {
+		realNodeMap[realNodes[i].ID] = &realNodes[i]
+	}
+
+	// --- Orchestrator reconciliation ---
+	if realOrch != nil {
+		if state.Orchestrator != nil {
+			// Merge: reality wins for runtime fields, keep metadata from state
+			log.Printf("  orchestrator: running (PID %d), merging with cached state", realOrch.PID)
+			mergeVMEntry(state.Orchestrator, realOrch)
+		} else {
+			log.Printf("  orchestrator: running (PID %d) but not in cluster.json — adopting", realOrch.PID)
+			realOrch.Status = "active"
+			state.SetOrchestrator(*realOrch)
+		}
+	} else if state.Orchestrator != nil {
+		if state.Orchestrator.Status == "upgrading" && fileExists(state.Orchestrator.Disk) {
+			log.Printf("  orchestrator: not running but status=upgrading with disk present — keeping for upgrade cycle")
+		} else {
+			log.Printf("  orchestrator: in cluster.json (PID %d) but no QEMU process — clearing stale entry", state.Orchestrator.PID)
+			state.Orchestrator.PID = 0
 		}
 	}
 
-	if discovered > 0 {
-		log.Printf("  Recovered %d orphaned VM(s) from running QEMU processes", discovered)
-		state.Save()
+	// --- Node reconciliation ---
+	// 1. Update/adopt nodes that are actually running
+	for id, realNode := range realNodeMap {
+		existing := state.GetNode(id)
+		if existing != nil {
+			log.Printf("  %s: running (PID %d), merging with cached state", id, realNode.PID)
+			mergeVMEntry(existing, realNode)
+			state.AddNode(*existing)
+		} else {
+			log.Printf("  %s: running (PID %d) but not in cluster.json — adopting", id, realNode.PID)
+			realNode.Status = "active"
+			state.AddNode(*realNode)
+		}
 	}
+
+	// 2. Remove stale nodes from cluster.json that have no running QEMU process
+	var staleNodeIDs []string
+	for _, node := range state.Nodes {
+		if _, running := realNodeMap[node.ID]; running {
+			continue // backed by a real process
+		}
+		// Not running. Keep if mid-upgrade/drain with disk still on disk.
+		if (node.Status == "draining" || node.Status == "upgrading") && fileExists(node.Disk) {
+			log.Printf("  %s: not running but status=%s with disk present — keeping for lifecycle completion", node.ID, node.Status)
+			node.PID = 0
+			state.AddNode(node) // update PID=0
+			continue
+		}
+		log.Printf("  %s: in cluster.json (PID %d) but no QEMU process — removing stale entry", node.ID, node.PID)
+		staleNodeIDs = append(staleNodeIDs, node.ID)
+	}
+	for _, id := range staleNodeIDs {
+		state.RemoveNode(id)
+	}
+
+	state.Save()
+	log.Printf("Reconciliation complete: orchestrator=%v, nodes=%d (removed %d stale)",
+		state.Orchestrator != nil, state.NodeCount(), len(staleNodeIDs))
+}
+
+// mergeVMEntry updates a cached VMEntry with runtime values from a running
+// QEMU process, keeping metadata that can only come from cluster.json.
+func mergeVMEntry(cached, real *cluster.VMEntry) {
+	// Reality wins for runtime fields
+	cached.PID = real.PID
+	if real.TAP != "" {
+		cached.TAP = real.TAP
+	}
+	if real.MAC != "" {
+		cached.MAC = real.MAC
+	}
+	if real.VCPU > 0 {
+		cached.VCPU = real.VCPU
+	}
+	if real.RAM != "" {
+		cached.RAM = real.RAM
+	}
+	if real.Disk != "" {
+		cached.Disk = real.Disk
+	}
+	if real.ISO != "" {
+		cached.ISO = real.ISO
+	}
+	if real.BridgeIP != "" {
+		cached.BridgeIP = real.BridgeIP
+	}
+	// Keep from cache: Status, ImageVersion, ImageCommit, ImageDigest, DrainFailCount
 }
 
 // parseQEMUArgs extracts VM identity from QEMU command-line arguments.
@@ -651,12 +703,11 @@ func parseQEMUArgs(args []string, pid int, cfg HostConfig) *cluster.VMEntry {
 }
 
 func bootRecover(cfg HostConfig, state *cluster.State) {
-	// Reconcile tracked PIDs: verify each PID is actually a QEMU process,
-	// not a reused PID from another process after a host restart.
-	reconcileTrackedPIDs(state)
-
-	// Then discover any running QEMU VMs not tracked in state
-	discoverOrphanedVMs(cfg, state)
+	// Phase 1: Reconcile state from reality. Scan running QEMU processes,
+	// adopt unknown VMs, remove stale entries, merge metadata from cluster.json.
+	// This replaces the old reconcileTrackedPIDs + discoverOrphanedVMs flow.
+	// See issue #135: "Reality is the source of truth. cluster.json is a cache."
+	reconcileFromReality(cfg, state)
 
 	currentUser, _ := user.Current()
 	username := "root"
@@ -2569,6 +2620,25 @@ func drainNode(cfg HostConfig, state *cluster.State, nodeID string) {
 
 	log.Printf("Drain: stopping %s", nodeID)
 
+	// Issue #138: final safety check — confirm node agent reports 0 VMs
+	// before destroying the QEMU node. A node with VMs must NEVER be destroyed.
+	if node.BridgeIP != "" {
+		safetyClient := &http.Client{Timeout: 5 * time.Second}
+		safetyResp, safetyErr := safetyClient.Get(fmt.Sprintf("http://%s:8800/api/vms", node.BridgeIP))
+		if safetyErr == nil {
+			var remainingVMs []interface{}
+			json.NewDecoder(safetyResp.Body).Decode(&remainingVMs)
+			safetyResp.Body.Close()
+			if len(remainingVMs) > 0 {
+				log.Printf("Drain: ABORTING stop of %s — node still has %d VM(s) after drain", nodeID, len(remainingVMs))
+				state.SetNodeStatus(nodeID, "active")
+				state.Save()
+				return
+			}
+		}
+		// If node is unreachable, proceed — it was already drained
+	}
+
 	// Clear drain target tracking on success
 	if goal := state.UpgradeGoal; goal != nil {
 		goal.DrainTargetNodeID = ""
@@ -4478,7 +4548,7 @@ func cliRecover() {
 	}
 
 	fmt.Println("Scanning for running QEMU VMs...")
-	discoverOrphanedVMs(cfg, state)
+	reconcileFromReality(cfg, state)
 
 	// Print what we found
 	if state.Orchestrator != nil {

--- a/host/cmd/host/main.go
+++ b/host/cmd/host/main.go
@@ -2626,11 +2626,19 @@ func drainNode(cfg HostConfig, state *cluster.State, nodeID string) {
 		safetyClient := &http.Client{Timeout: 5 * time.Second}
 		safetyResp, safetyErr := safetyClient.Get(fmt.Sprintf("http://%s:8800/api/vms", node.BridgeIP))
 		if safetyErr == nil {
-			var remainingVMs []interface{}
-			json.NewDecoder(safetyResp.Body).Decode(&remainingVMs)
-			safetyResp.Body.Close()
-			if len(remainingVMs) > 0 {
-				log.Printf("Drain: ABORTING stop of %s — node still has %d VM(s) after drain", nodeID, len(remainingVMs))
+			if safetyResp.StatusCode == http.StatusOK {
+				var remainingVMs []interface{}
+				json.NewDecoder(safetyResp.Body).Decode(&remainingVMs)
+				safetyResp.Body.Close()
+				if len(remainingVMs) > 0 {
+					log.Printf("Drain: ABORTING stop of %s — node still has %d VM(s) after drain", nodeID, len(remainingVMs))
+					state.SetNodeStatus(nodeID, "active")
+					state.Save()
+					return
+				}
+			} else {
+				safetyResp.Body.Close()
+				log.Printf("Drain: safety check on %s returned HTTP %d — aborting stop to be safe", nodeID, safetyResp.StatusCode)
 				state.SetNodeStatus(nodeID, "active")
 				state.Save()
 				return

--- a/orchestrator/internal/api/handlers.go
+++ b/orchestrator/internal/api/handlers.go
@@ -624,74 +624,95 @@ type vmListEntry struct {
 }
 
 func (h *Handler) handleVMList(w http.ResponseWriter, r *http.Request) {
-	vms := h.state.ListVMs()
+	// Issue #138: nodes are the source of truth. Query ALL active nodes
+	// for their VM inventory, then merge with orchestrator state for labels
+	// and other metadata. This ensures ghost VMs are always visible.
+	activeNodes := h.state.ListNodes()
 
-	// Group VMs by node so we make one request per node
-	nodeVMs := make(map[string][]*state.VM)
-	for _, v := range vms {
-		nodeVMs[v.NodeID] = append(nodeVMs[v.NodeID], v)
-	}
-
-	// Fetch details from each node in parallel
 	type nodeResult struct {
 		nodeID string
-		vms    map[string]*node.VMDetail
+		vms    []node.VMDetail
 	}
-	results := make(chan nodeResult, len(nodeVMs))
+	results := make(chan nodeResult, len(activeNodes))
 
-	for nodeID := range nodeVMs {
-		go func(nid string) {
-			nr := nodeResult{nodeID: nid, vms: make(map[string]*node.VMDetail)}
-			n := h.state.GetNode(nid)
-			if n == nil || n.APIAddr == "" {
+	for _, n := range activeNodes {
+		go func(nid, addr string) {
+			nr := nodeResult{nodeID: nid}
+			if addr == "" {
 				results <- nr
 				return
 			}
-			fc := node.NewFastClient(n.APIAddr)
-			vmList := fc.ListVMs()
-			for i := range vmList {
-				nr.vms[vmList[i].Name] = &vmList[i]
-			}
+			fc := node.NewFastClient(addr)
+			nr.vms = fc.ListVMs()
 			results <- nr
-		}(nodeID)
+		}(n.ID, n.APIAddr)
 	}
 
+	// Collect node responses — these are the real VMs
+	// Map: nodeID -> (vmName -> VMDetail)
 	detailsByNode := make(map[string]map[string]*node.VMDetail)
-	for range nodeVMs {
+	for range activeNodes {
 		nr := <-results
-		detailsByNode[nr.nodeID] = nr.vms
+		m := make(map[string]*node.VMDetail)
+		for i := range nr.vms {
+			m[nr.vms[i].Name] = &nr.vms[i]
+		}
+		detailsByNode[nr.nodeID] = m
 	}
 
+	// Build entries from node reality, enriched with orchestrator metadata
+	seen := make(map[string]bool)
 	var entries []vmListEntry
-	for _, v := range vms {
+
+	for nodeID, nodeVMs := range detailsByNode {
+		n := h.state.GetNode(nodeID)
+		nodeName := nodeID
+		if n != nil {
+			nodeName = n.TailscaleName
+		}
+
+		for vmName, detail := range nodeVMs {
+			seen[vmName] = true
+			orchVM := h.state.GetVM(vmName)
+
+			entry := vmListEntry{
+				Name:        vmName,
+				NodeID:      nodeID,
+				NodeName:    nodeName,
+				Type:        detail.Type,
+				Description: detail.Description,
+				TailscaleIP: detail.TailscaleIP,
+				Mode:        detail.Mode,
+				VCPU:        detail.VCPU,
+				RAMMIB:      detail.RAMMIB,
+				Disk:        detail.Disk,
+				Status:      detail.Status,
+			}
+			if orchVM != nil {
+				entry.Labels = orchVM.Labels
+			}
+			entries = append(entries, entry)
+		}
+	}
+
+	// Include VMs from orchestrator state on unreachable nodes (so they
+	// don't vanish from the list when a node is temporarily down).
+	for _, v := range h.state.ListVMs() {
+		if seen[v.Name] {
+			continue
+		}
 		n := h.state.GetNode(v.NodeID)
 		nodeName := v.NodeID
 		if n != nil {
 			nodeName = n.TailscaleName
 		}
-
-		entry := vmListEntry{
+		entries = append(entries, vmListEntry{
 			Name:     v.Name,
 			NodeID:   v.NodeID,
 			NodeName: nodeName,
 			Status:   v.Status,
 			Labels:   v.Labels,
-		}
-
-		if nodeDetail, ok := detailsByNode[v.NodeID]; ok {
-			if detail, ok := nodeDetail[v.Name]; ok {
-				entry.Type = detail.Type
-				entry.Description = detail.Description
-				entry.TailscaleIP = detail.TailscaleIP
-				entry.Mode = detail.Mode
-				entry.VCPU = detail.VCPU
-				entry.RAMMIB = detail.RAMMIB
-				entry.Disk = detail.Disk
-				entry.Status = detail.Status
-			}
-		}
-
-		entries = append(entries, entry)
+		})
 	}
 
 	writeJSON(w, entries)
@@ -817,18 +838,27 @@ func (h *Handler) handleVMDestroy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	n := h.state.GetNode(vm.NodeID)
+	if n == nil {
+		http.Error(w, "node not found for VM", http.StatusInternalServerError)
+		return
+	}
+
+	// Issue #138: the node agent is the source of truth. We must confirm
+	// destruction on the node before removing from orchestrator state.
+	// Never delete state if the node call fails — that creates ghost VMs.
 	h.state.UpdateVMStatus(name, "destroying")
 
-	n := h.state.GetNode(vm.NodeID)
-	if n != nil {
-		client := node.NewClient(n.APIAddr)
-		if err := client.Destroy(name); err != nil {
-			log.Printf("Node destroy failed for %s: %v (cleaning up state anyway)", name, err)
-		}
+	client := node.NewClient(n.APIAddr)
+	if err := client.Destroy(name); err != nil {
+		h.state.UpdateVMStatus(name, vm.Status) // revert status
+		log.Printf("Node destroy failed for %s on %s: %v", name, vm.NodeID, err)
+		http.Error(w, fmt.Sprintf("node agent destroy failed: %v", err), http.StatusBadGateway)
+		return
 	}
 
 	h.state.DeleteVM(name)
-	log.Printf("VM destroyed: %s", name)
+	log.Printf("VM destroyed: %s (confirmed by node %s)", name, vm.NodeID)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/orchestrator/internal/state/state.go
+++ b/orchestrator/internal/state/state.go
@@ -226,6 +226,18 @@ func (s *Store) SyncNodeVMs(nodeID string, vms []VM) {
 	}
 }
 
+// NodeHasVMs returns true if any VM in the store is assigned to the given node.
+func (s *Store) NodeHasVMs(nodeID string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, v := range s.vms {
+		if v.NodeID == nodeID {
+			return true
+		}
+	}
+	return false
+}
+
 // --- Golden image operations ---
 
 // SetGoldenImages replaces all golden image records for a node.


### PR DESCRIPTION
## Summary

- **Host control plane (#135)**: On boot, scan running QEMU processes first and build state from reality instead of trusting cluster.json. Stale entries are removed, unknown VMs are adopted, and metadata (UpgradeGoal, image digests) is preserved from the cache. Deleting cluster.json and restarting now rediscovers all running nodes. Adds a final safety check in `drainNode` that confirms 0 VMs on the node agent before destroying the QEMU process.
- **Orchestrator (#138)**: `handleVMDestroy` now returns 502 if the node agent destroy call fails instead of silently deleting state (preventing ghost VMs). `handleVMList` queries all active nodes as source of truth and discovers VMs the orchestrator doesn't know about, falling back to cached state for unreachable nodes.

## Changes

| File | What changed |
|------|-------------|
| `host/cmd/host/main.go` | Replace `reconcileTrackedPIDs` + `discoverOrphanedVMs` with `scanRunningVMs` + `reconcileFromReality` + `mergeVMEntry`. Add VM safety check before node stop in `drainNode`. |
| `orchestrator/internal/api/handlers.go` | Rewrite `handleVMDestroy` to require node confirmation. Rewrite `handleVMList` to query all nodes as source of truth. |
| `orchestrator/internal/state/state.go` | Add `NodeHasVMs` helper. |

## Test plan

- [ ] Delete `cluster.json`, restart `boxcutter-host` — all running nodes discovered and managed
- [ ] Add a rogue QEMU node process — adopted into state on next boot
- [ ] Stale `cluster.json` entries cleaned on boot, no health monitor spam
- [ ] Destroy a VM when node is unreachable — returns 502, VM stays in state
- [ ] Destroy a VM normally — confirmed by node, removed from state
- [ ] `GET /api/vms` returns VMs from nodes even if orchestrator state is empty
- [ ] Upgrade completes without any `cluster.json` editing

Closes #135, closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)