### PR TITLE
Fix #116: agent health dashboard with SSE alerts and team grouping

### DIFF
--- a/orchestrator/internal/api/handlers.go
+++ b/orchestrator/internal/api/handlers.go
@@ -303,6 +303,10 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	// VM-to-VM messaging: lookup which node a VM is on
 	mux.HandleFunc("GET /api/vms/{name}/location", h.handleVMLocation)
 
+	// Dashboard: SSE stream + alerts
+	mux.HandleFunc("GET /api/alerts", h.handleAlerts)
+	mux.HandleFunc("GET /api/alerts/stream", h.handleAlertStream)
+
 	// Work queue
 	mux.HandleFunc("GET /api/queue", h.handleQueueList)
 	mux.HandleFunc("POST /api/queue", h.handleQueueAdd)
@@ -1973,9 +1977,6 @@ func (h *Handler) detectAlerts() {
 	}
 
 	// Fetch activity from each node concurrently
-	type nodeResult struct {
-		activities []node.TapegunVMActivity
-	}
 	results := make(chan struct {
 		nodeID string
 		acts   []node.TapegunVMActivity


### PR DESCRIPTION
## Summary
- Adds real-time agent health dashboard with SSE-powered alert stream to replace manual `tapegun activity` polling
- Backend: alert detection loop (15s interval) detects status transitions (crash, idle, recovery, unresponsive) and pane content errors (auth failures, OOM, FATAL), emits via SSE with 30s heartbeat
- Frontend: team-grouped activity view with aggregate stats bar and alert feed sidebar, SSE with polling fallback

## Changes

**Orchestrator (`orchestrator/internal/api/handlers.go`):**
- `AlertEvent` type + 200-event ring buffer
- `alertDetectionLoop` — polls all nodes every 15s, compares previous vs current status/health
- State transition detection: active→stopped (crash), active→idle, stopped→active (recovery), unresponsive (>60s no report)
- Pane content error detection: `401 Unauthorized`, `token expired`, `OOMKilled`, `FATAL`
- `GET /api/alerts` — REST endpoint for initial alert load
- `GET /api/alerts/stream` — SSE endpoint with heartbeat
- `teamForVM()` — extracts team name from VM naming convention

**Web (`web/`):**
- Team-grouped activity view replacing flat grid
- Aggregate stats bar (N agents, N active, N idle, N crashed)
- Status color dots (green/yellow/red/gray) based on VM + activity status
- Alert feed sidebar with newest-first chronological list
- SSE connection with automatic polling fallback on disconnect
- `AlertEvent` type added to `lib/types.ts`
- Proxy route `app/api/alerts/route.ts`

## Test plan
- [ ] SSE endpoint streams alerts in real-time (<15s latency from state change)
- [ ] Dashboard groups agents by team with correct status indicators
- [ ] Aggregate stats bar updates as agents change state
- [ ] Alert feed shows crash/idle/recovery/error transitions
- [ ] Unresponsive detection fires after 60s of no reports
- [ ] Auth error and OOM patterns detected in pane content
- [ ] Dashboard falls back to polling when SSE connection drops
- [ ] Non-team VMs appear under "Other VMs" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)