### PR TITLE
Fix #108: complete team YAML e2e integration test

### DIFF
--- a/host/test-team-e2e-scale.yaml
+++ b/host/test-team-e2e-scale.yaml
@@ -20,12 +20,17 @@ spec:
       vcpu: 2
       persona:
         role: test-lead
+        claude_md: .claude/personas/eng-manager.md
         instructions: |
           You are the test lead. Respond to any message with "LEAD READY".
+      tapegun:
+        - guest
+        - host
 
     - name: worker
       replicas: 3
       persona:
         role: test-worker
+        claude_md: .claude/personas/developer.md
         instructions: |
           You are a test worker. Respond to any message with "WORKER READY".

--- a/host/test-team-e2e-scaledown.yaml
+++ b/host/test-team-e2e-scaledown.yaml
@@ -20,12 +20,17 @@ spec:
       vcpu: 2
       persona:
         role: test-lead
+        claude_md: .claude/personas/eng-manager.md
         instructions: |
           You are the test lead. Respond to any message with "LEAD READY".
+      tapegun:
+        - guest
+        - host
 
     - name: worker
       replicas: 1
       persona:
         role: test-worker
+        claude_md: .claude/personas/developer.md
         instructions: |
           You are a test worker. Respond to any message with "WORKER READY".

--- a/host/test-team-e2e.sh
+++ b/host/test-team-e2e.sh
@@ -3,14 +3,20 @@
 # Requires a running cluster with orchestrator + at least 1 node.
 #
 # Tests:
-#   1. team apply creates VMs with correct names
-#   2. team list shows the team
-#   3. team status shows VM status
-#   4. re-apply is idempotent (no-op)
-#   5. scale-up creates additional VMs
-#   6. scale-down destroys excess VMs
-#   7. team destroy removes all VMs
-#   8. invalid YAML produces clear error
+#   1.  team apply creates VMs with correct names
+#   2.  team list shows the team
+#   3.  team status shows VM status
+#   4.  metadata endpoint serves correct agent-config per VM
+#   5.  persona files installed correctly on VMs
+#   6.  Claude Code running (tapegun active with tmux session)
+#   7.  tapegun inbox messaging works (plugin installed)
+#   8.  re-apply is idempotent (no-op)
+#   9.  scale-up creates additional VMs
+#   10. scale-down destroys excess VMs
+#   11. crash recovery: kill Claude Code -> tapegun restarts it
+#   12. team destroy removes all VMs
+#   13. invalid YAML produces clear error
+#   14. existing VMs unaffected
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -29,6 +35,25 @@ fail() { log "FAIL: $*"; FAIL=$((FAIL+1)); TOTAL=$((TOTAL+1)); }
 skip() { log "SKIP: $*"; TOTAL=$((TOTAL+1)); }
 
 orch_ssh() { ssh -i "$SSH_KEY" $SSH_OPTS boxcutter@"$ORCH_IP" "$@" 2>/dev/null; }
+
+# wait_for_vm_ready polls until a VM's tapegun is reporting activity.
+# Usage: wait_for_vm_ready <vm_name> <timeout_seconds>
+wait_for_vm_ready() {
+  local vm="$1" timeout="${2:-180}"
+  log "  Waiting for $vm to be ready (up to ${timeout}s)..."
+  for i in $(seq 1 "$((timeout / 5))"); do
+    local activity
+    activity=$(orch_ssh "tapegun activity $vm" 2>&1 || true)
+    if echo "$activity" | grep -qi "active\|idle\|pane_content"; then
+      log "  $vm is ready (${i}x5s)"
+      return 0
+    fi
+    [ $((i % 6)) -eq 0 ] && log "  Still waiting for $vm... ($((i*5))s)"
+    sleep 5
+  done
+  log "  WARNING: $vm did not become ready within ${timeout}s"
+  return 1
+}
 
 # --- Pre-flight: verify orchestrator is reachable ---
 log "=== Pre-flight ==="
@@ -86,8 +111,170 @@ for VM_NAME in test-team-lead-1 test-team-worker-1 test-team-worker-2; do
   fi
 done
 
-# --- Test 4: re-apply is idempotent ---
-log "=== Test 4: idempotent re-apply ==="
+# --- Wait for VMs to boot and tapegun to set up ---
+log "=== Waiting for VMs to be ready ==="
+LEAD_READY=false
+WORKER_READY=false
+if wait_for_vm_ready "test-team-lead-1" 180; then
+  LEAD_READY=true
+fi
+if wait_for_vm_ready "test-team-worker-1" 180; then
+  WORKER_READY=true
+fi
+
+# --- Test 4: metadata endpoint serves correct agent-config ---
+log "=== Test 4: metadata agent-config ==="
+if [ "$LEAD_READY" = "true" ]; then
+  LEAD_CONFIG=$(orch_ssh "exec test-team-lead-1 curl -sf http://169.254.169.254/metadata/agent-config" 2>&1 || true)
+  echo "  lead agent-config: $LEAD_CONFIG"
+
+  if echo "$LEAD_CONFIG" | grep -q '"team".*:.*"test-team"'; then
+    pass "lead agent-config has team=test-team"
+  else
+    fail "lead agent-config missing team field"
+  fi
+
+  if echo "$LEAD_CONFIG" | grep -q '"agent".*:.*"lead"'; then
+    pass "lead agent-config has agent=lead"
+  else
+    fail "lead agent-config missing agent field"
+  fi
+
+  if echo "$LEAD_CONFIG" | grep -q '"role".*:.*"test-lead"'; then
+    pass "lead agent-config has persona role=test-lead"
+  else
+    fail "lead agent-config missing persona role"
+  fi
+else
+  skip "lead VM not ready — cannot test metadata endpoint"
+  skip "lead agent-config team field"
+  skip "lead agent-config persona role"
+fi
+
+if [ "$WORKER_READY" = "true" ]; then
+  WORKER_CONFIG=$(orch_ssh "exec test-team-worker-1 curl -sf http://169.254.169.254/metadata/agent-config" 2>&1 || true)
+  if echo "$WORKER_CONFIG" | grep -q '"agent".*:.*"worker"'; then
+    pass "worker agent-config has agent=worker"
+  else
+    fail "worker agent-config missing agent field"
+  fi
+else
+  skip "worker VM not ready — cannot test metadata endpoint"
+fi
+
+# --- Test 5: persona files installed correctly ---
+log "=== Test 5: persona files ==="
+if [ "$LEAD_READY" = "true" ]; then
+  # Lead should have eng-manager.md persona
+  LEAD_PERSONAS=$(orch_ssh "exec test-team-lead-1 ls .claude/personas/ 2>/dev/null" 2>&1 || true)
+  echo "  lead personas: $LEAD_PERSONAS"
+
+  if echo "$LEAD_PERSONAS" | grep -q "eng-manager.md"; then
+    pass "lead has eng-manager.md persona"
+  else
+    fail "lead missing eng-manager.md persona"
+  fi
+
+  # Lead should NOT have developer.md (other agent's persona)
+  if echo "$LEAD_PERSONAS" | grep -q "developer.md"; then
+    fail "lead has developer.md (should be removed)"
+  else
+    pass "lead does not have developer.md (correctly removed)"
+  fi
+
+  # Check persona content includes inline instructions
+  LEAD_PERSONA_CONTENT=$(orch_ssh "exec test-team-lead-1 cat .claude/personas/eng-manager.md 2>/dev/null" 2>&1 || true)
+  if echo "$LEAD_PERSONA_CONTENT" | grep -q "LEAD READY"; then
+    pass "lead persona contains inline instructions"
+  else
+    fail "lead persona missing inline instructions"
+  fi
+else
+  skip "lead VM not ready — cannot test persona files"
+  skip "lead developer.md removal"
+  skip "lead persona instructions"
+fi
+
+if [ "$WORKER_READY" = "true" ]; then
+  WORKER_PERSONAS=$(orch_ssh "exec test-team-worker-1 ls .claude/personas/ 2>/dev/null" 2>&1 || true)
+  echo "  worker personas: $WORKER_PERSONAS"
+
+  if echo "$WORKER_PERSONAS" | grep -q "developer.md"; then
+    pass "worker has developer.md persona"
+  else
+    fail "worker missing developer.md persona"
+  fi
+
+  if echo "$WORKER_PERSONAS" | grep -q "eng-manager.md"; then
+    fail "worker has eng-manager.md (should be removed)"
+  else
+    pass "worker does not have eng-manager.md (correctly removed)"
+  fi
+else
+  skip "worker VM not ready — cannot test persona files"
+  skip "worker eng-manager.md removal"
+fi
+
+# --- Test 6: Claude Code running (tapegun active) ---
+log "=== Test 6: Claude Code running ==="
+if [ "$LEAD_READY" = "true" ]; then
+  # Check tapegun daemon is active
+  TAPEGUN_STATUS=$(orch_ssh "exec test-team-lead-1 systemctl is-active boxcutter-tapegun" 2>&1 | tr -d '\n')
+  if [ "$TAPEGUN_STATUS" = "active" ]; then
+    pass "lead tapegun daemon is active"
+  else
+    fail "lead tapegun daemon not active (status: $TAPEGUN_STATUS)"
+  fi
+
+  # Check tmux session exists
+  TMUX_CHECK=$(orch_ssh "exec test-team-lead-1 tmux has-session -t main 2>&1; echo \$?" 2>&1 | tail -1)
+  if [ "$TMUX_CHECK" = "0" ]; then
+    pass "lead has tmux session 'main'"
+  else
+    fail "lead missing tmux session 'main'"
+  fi
+
+  # Check Claude Code process running
+  CLAUDE_PID=$(orch_ssh "exec test-team-lead-1 pgrep -f claude -u 1000" 2>&1 || true)
+  if [ -n "$CLAUDE_PID" ]; then
+    pass "lead has Claude Code process running"
+  else
+    fail "lead has no Claude Code process"
+  fi
+else
+  skip "lead VM not ready — cannot test Claude Code"
+  skip "lead tmux session"
+  skip "lead Claude Code process"
+fi
+
+# --- Test 7: tapegun inbox messaging (plugin installed) ---
+log "=== Test 7: tapegun inbox messaging ==="
+if [ "$LEAD_READY" = "true" ]; then
+  # Check plugin is installed
+  PLUGIN_CHECK=$(orch_ssh "exec test-team-lead-1 test -f /home/dev/.claude/plugins/tapegun-guest/.claude-plugin/plugin.json && echo present" 2>&1 || true)
+  if echo "$PLUGIN_CHECK" | grep -q "present"; then
+    pass "lead has tapegun-guest plugin installed"
+  else
+    fail "lead missing tapegun-guest plugin"
+  fi
+
+  # Send a message and verify delivery
+  orch_ssh "tapegun send test-team-lead-1 'E2E_TEST_MESSAGE_$(date +%s)'" >/dev/null 2>&1 || true
+  sleep 8  # Wait for tapegun polling cycle (5s interval)
+
+  INBOX=$(orch_ssh "exec test-team-lead-1 cat /home/dev/.tapegun/inbox.json 2>/dev/null" 2>&1 || true)
+  if echo "$INBOX" | grep -q "E2E_TEST_MESSAGE"; then
+    pass "tapegun inbox message delivered to lead"
+  else
+    fail "tapegun inbox message not delivered to lead"
+  fi
+else
+  skip "lead VM not ready — cannot test plugin"
+  skip "lead inbox messaging"
+fi
+
+# --- Test 8: re-apply is idempotent ---
+log "=== Test 8: idempotent re-apply ==="
 REAPPLY_OUT=$(cat "$SCRIPT_DIR/test-team-e2e.yaml" | orch_ssh "team apply -f -" 2>&1)
 echo "$REAPPLY_OUT"
 
@@ -99,8 +286,8 @@ else
   fail "re-apply was not idempotent"
 fi
 
-# --- Test 5: scale-up ---
-log "=== Test 5: scale-up (workers 2→3) ==="
+# --- Test 9: scale-up ---
+log "=== Test 9: scale-up (workers 2→3) ==="
 SCALE_UP_OUT=$(cat "$SCRIPT_DIR/test-team-e2e-scale.yaml" | orch_ssh "team apply -f -" 2>&1)
 echo "$SCALE_UP_OUT"
 
@@ -120,8 +307,8 @@ else
   fail "test-team-worker-3 missing after scale-up"
 fi
 
-# --- Test 6: scale-down ---
-log "=== Test 6: scale-down (workers 3→1) ==="
+# --- Test 10: scale-down ---
+log "=== Test 10: scale-down (workers 3→1) ==="
 SCALE_DOWN_OUT=$(cat "$SCRIPT_DIR/test-team-e2e-scaledown.yaml" | orch_ssh "team apply -f -" 2>&1)
 echo "$SCALE_DOWN_OUT"
 
@@ -146,8 +333,35 @@ else
   pass "test-team-worker-3 removed after scale-down"
 fi
 
-# --- Test 7: team destroy ---
-log "=== Test 7: team destroy ==="
+# --- Test 11: crash recovery ---
+log "=== Test 11: crash recovery ==="
+if [ "$LEAD_READY" = "true" ]; then
+  # Kill Claude Code process and verify tapegun restarts it
+  orch_ssh "exec test-team-lead-1 pkill -f claude -u 1000" >/dev/null 2>&1 || true
+  log "  Killed Claude Code on lead, waiting for tapegun restart..."
+
+  RECOVERED=false
+  for i in $(seq 1 12); do
+    sleep 5
+    CLAUDE_PID=$(orch_ssh "exec test-team-lead-1 pgrep -f claude -u 1000" 2>&1 || true)
+    if [ -n "$CLAUDE_PID" ]; then
+      RECOVERED=true
+      log "  Claude Code recovered after $((i*5))s"
+      break
+    fi
+  done
+
+  if [ "$RECOVERED" = "true" ]; then
+    pass "crash recovery: Claude Code restarted by tapegun"
+  else
+    fail "crash recovery: Claude Code not restarted within 60s"
+  fi
+else
+  skip "lead VM not ready — cannot test crash recovery"
+fi
+
+# --- Test 12: team destroy ---
+log "=== Test 12: team destroy ==="
 DESTROY_OUT=$(orch_ssh "team destroy test-team" 2>&1)
 echo "$DESTROY_OUT"
 
@@ -160,8 +374,8 @@ else
   fail "team destroy did not remove all VMs"
 fi
 
-# --- Test 8: invalid YAML ---
-log "=== Test 8: invalid YAML ==="
+# --- Test 13: invalid YAML ---
+log "=== Test 13: invalid YAML ==="
 INVALID_OUT=$(echo "not: valid: team: yaml" | orch_ssh "team apply -f -" 2>&1)
 if echo "$INVALID_OUT" | grep -qi "error"; then
   pass "invalid YAML produces error"
@@ -169,8 +383,8 @@ else
   fail "invalid YAML did not produce error"
 fi
 
-# --- Test 9: verify existing VMs unaffected ---
-log "=== Test 9: existing VMs unaffected ==="
+# --- Test 14: verify existing VMs unaffected ---
+log "=== Test 14: existing VMs unaffected ==="
 FINAL_VMS=$(orch_ssh "list" 2>/dev/null | tail -n +2 | wc -l)
 if [ "$FINAL_VMS" -eq "$EXISTING_VMS" ]; then
   pass "existing VMs unaffected ($EXISTING_VMS VMs)"

--- a/host/test-team-e2e.yaml
+++ b/host/test-team-e2e.yaml
@@ -20,12 +20,17 @@ spec:
       vcpu: 2
       persona:
         role: test-lead
+        claude_md: .claude/personas/eng-manager.md
         instructions: |
           You are the test lead. Respond to any message with "LEAD READY".
+      tapegun:
+        - guest
+        - host
 
     - name: worker
       replicas: 2
       persona:
         role: test-worker
+        claude_md: .claude/personas/developer.md
         instructions: |
           You are a test worker. Respond to any message with "WORKER READY".


### PR DESCRIPTION
## Summary

- Extends `test-team-e2e.sh` with the missing acceptance criteria from issue #108, covering the full team YAML MVP pipeline end-to-end
- Updates YAML fixtures to include `claude_md` persona paths and `tapegun` feature lists, exercising the full agent-config -> metadata -> tapegun -> persona pipeline

## New tests added

| Test | What it verifies |
|------|-----------------|
| 4. Metadata agent-config | Each VM gets correct team/agent/role from `169.254.169.254/metadata/agent-config` |
| 5. Persona files | Lead has `eng-manager.md`, worker has `developer.md`; other agents' personas removed |
| 6. Claude Code running | Tapegun daemon active, tmux session exists, Claude process alive |
| 7. Inbox messaging | tapegun-guest plugin installed, message delivered via tapegun send |
| 11. Crash recovery | Kill Claude Code process, verify tapegun restarts it within 60s |

## Test plan

- [ ] Run `host/test-team-e2e.sh` on a live cluster with orchestrator + node
- [ ] All 14 tests pass (or skip gracefully if VMs not ready)
- [ ] Existing tests (apply, list, status, idempotency, scale, destroy) still pass
- [ ] Verify `bash -n host/test-team-e2e.sh` passes (syntax check: done)

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)