### PR TITLE
Fix #145: node stop/remove safety — refuse when VMs present

### DIFF
--- a/host/cmd/host/main.go
+++ b/host/cmd/host/main.go
@@ -364,7 +364,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  pull <type> [--tag TAG]      Pull a VM image from OCI registry\n")
 		fmt.Fprintf(os.Stderr, "  upgrade <type> [--tag TAG]   Rolling upgrade of VMs\n")
 		fmt.Fprintf(os.Stderr, "  stop-node <id> [--force] [--delete-disk]  Stop a node and remove from state\n")
-		fmt.Fprintf(os.Stderr, "  remove-node <id>             Remove a node entry (kills QEMU if running)\n")
+		fmt.Fprintf(os.Stderr, "  remove-node <id> [--force]    Remove a node entry (kills QEMU if running)\n")
 		fmt.Fprintf(os.Stderr, "  list-orphans                 Show nodes with 0 VMs (cleanup candidates)\n")
 		fmt.Fprintf(os.Stderr, "  cleanup-nodes                Remove all orphan nodes\n")
 		fmt.Fprintf(os.Stderr, "  team apply -f team.yaml      Create/update team from YAML spec\n")
@@ -1318,6 +1318,22 @@ func queryNodeVMs(bridgeIP string) []map[string]interface{} {
 	var result []map[string]interface{}
 	json.NewDecoder(resp.Body).Decode(&result)
 	return result
+}
+
+// queryNodeVMNames returns the names of VMs on a node, or nil if unreachable.
+// Used by stop-node and remove-node safety checks (issue #145).
+func queryNodeVMNames(bridgeIP string) []string {
+	vms := queryNodeVMs(bridgeIP)
+	if len(vms) == 0 {
+		return nil
+	}
+	var names []string
+	for _, vm := range vms {
+		if name, ok := vm["name"].(string); ok {
+			names = append(names, name)
+		}
+	}
+	return names
 }
 
 func canScaleUp(cfg HostConfig, currentNodeCount int) (bool, string) {
@@ -3000,18 +3016,17 @@ func cliStopNode() {
 		os.Exit(1)
 	}
 
-	// Check for VMs unless --force
+	// Check for VMs unless --force (issue #145: prevent accidental data loss)
 	if !force {
-		nodeClient := &http.Client{Timeout: 5 * time.Second}
-		resp, err := nodeClient.Get(fmt.Sprintf("http://%s:8800/api/vms", node.BridgeIP))
-		if err == nil {
-			var vms []interface{}
-			json.NewDecoder(resp.Body).Decode(&vms)
-			resp.Body.Close()
-			if len(vms) > 0 {
-				fmt.Fprintf(os.Stderr, "Node '%s' has %d running VM(s). Use --force to stop anyway.\n", nodeID, len(vms))
-				os.Exit(1)
+		vmNames := queryNodeVMNames(node.BridgeIP)
+		if len(vmNames) > 0 {
+			fmt.Fprintf(os.Stderr, "ERROR: Node '%s' has %d VM(s) that would be DESTROYED:\n", nodeID, len(vmNames))
+			for _, name := range vmNames {
+				fmt.Fprintf(os.Stderr, "  - %s\n", name)
 			}
+			fmt.Fprintf(os.Stderr, "\nUse --force to stop anyway, or drain the node first:\n")
+			fmt.Fprintf(os.Stderr, "  boxcutter-host drain %s\n", nodeID)
+			os.Exit(1)
 		}
 	}
 
@@ -3053,10 +3068,17 @@ func cliStopNode() {
 func cliRemoveNode() {
 	cfg := defaultConfig()
 	if len(os.Args) < 3 {
-		fmt.Println("Usage: boxcutter-host remove-node <node-id>")
+		fmt.Println("Usage: boxcutter-host remove-node <node-id> [--force]")
 		os.Exit(1)
 	}
 	nodeID := os.Args[2]
+
+	force := false
+	for _, arg := range os.Args[3:] {
+		if arg == "--force" {
+			force = true
+		}
+	}
 
 	state, err := cluster.Load(cfg.StatePath)
 	if err != nil {
@@ -3068,6 +3090,20 @@ func cliRemoveNode() {
 	if node == nil {
 		fmt.Fprintf(os.Stderr, "Node '%s' not found in cluster state\n", nodeID)
 		os.Exit(1)
+	}
+
+	// Issue #145: refuse to remove a node with VMs unless --force
+	if !force && qemu.IsRunning(node.PID) {
+		vmNames := queryNodeVMNames(node.BridgeIP)
+		if len(vmNames) > 0 {
+			fmt.Fprintf(os.Stderr, "ERROR: Node '%s' has %d VM(s) that would be DESTROYED:\n", nodeID, len(vmNames))
+			for _, name := range vmNames {
+				fmt.Fprintf(os.Stderr, "  - %s\n", name)
+			}
+			fmt.Fprintf(os.Stderr, "\nUse --force to remove anyway, or drain the node first:\n")
+			fmt.Fprintf(os.Stderr, "  boxcutter-host drain %s\n", nodeID)
+			os.Exit(1)
+		}
 	}
 
 	// Kill QEMU if running (prevents ghost re-adoption on daemon restart)


### PR DESCRIPTION
## Summary
- Prevents accidental VM data loss when manually stopping or removing nodes (v0.39.0 postmortem item #4)
- Both `stop-node` and `remove-node` now list affected VMs and refuse unless `--force` is passed
- Suggests `drain` as the safe alternative

## Context

From the v0.39.0 upgrade postmortem (#134):
> dev-worker-3 was on node-5. When node-5 was manually stopped to free RAM for the upgrade, its disk was destroyed. The VM could not be recovered.

`stop-node` had a basic VM count check but didn't list which VMs would be lost. `remove-node` had **no VM check at all** — it would silently kill QEMU and remove state.

## Changes

**`cliStopNode` (improved):**
- Now lists affected VM names instead of just a count
- Suggests `boxcutter-host drain <node>` as a safe alternative
- Uses shared `queryNodeVMNames()` helper

**`cliRemoveNode` (new safety check):**
- Added `--force` flag (previously had no override mechanism)
- Queries node for VMs before killing QEMU
- Shows same error format as `stop-node`

**New helper: `queryNodeVMNames()`**
- Wraps existing `queryNodeVMs()`, extracts just the name strings
- Returns nil if node is unreachable (allows removal of dead nodes without `--force`)

Example output:
```
ERROR: Node 'node-5' has 2 VM(s) that would be DESTROYED:
  - dev-worker-3
  - dev-worker-4

Use --force to stop anyway, or drain the node first:
  boxcutter-host drain node-5
```

## Test plan
- [ ] `stop-node <id>` with VMs present shows error with VM names
- [ ] `stop-node <id> --force` bypasses the check
- [ ] `remove-node <id>` with VMs present shows error with VM names
- [ ] `remove-node <id> --force` bypasses the check
- [ ] Unreachable nodes can still be removed (queryNodeVMNames returns nil)
- [ ] Automated drain (upgrade reconciler, auto-scaler) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)