### PR TITLE
Fix #148: team apply pushes agent-config updates to existing VMs

### DIFF
--- a/node/agent/internal/api/handlers.go
+++ b/node/agent/internal/api/handlers.go
@@ -69,6 +69,7 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/vms/{name}/projects", h.handleListProjects)
 	mux.HandleFunc("GET /api/vms/{name}/logs", h.handleLogs)
 	mux.HandleFunc("PATCH /api/vms/{name}", h.handleUpdate)
+	mux.HandleFunc("PUT /api/vms/{name}/agent-config", h.handleUpdateAgentConfig)
 	mux.HandleFunc("GET /api/golden/versions", h.handleGoldenVersions)
 	mux.HandleFunc("GET /api/golden/{version}", h.handleGoldenCheck)
 	mux.HandleFunc("POST /api/golden/build", h.handleGoldenBuild)
@@ -1137,4 +1138,29 @@ func (h *Handler) lookupVMLocation(vmName string) (string, error) {
 		return "", fmt.Errorf("no node_addr for %q", vmName)
 	}
 	return loc.NodeAddr, nil
+}
+
+// handleUpdateAgentConfig forwards an agent-config update to the vmid service.
+func (h *Handler) handleUpdateAgentConfig(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if name == "" {
+		http.Error(w, "name required", http.StatusBadRequest)
+		return
+	}
+	if h.vmidClient == nil {
+		http.Error(w, "vmid client not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "reading body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if err := h.vmidClient.SetAgentConfig(name, body); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/node/agent/internal/vmid/client.go
+++ b/node/agent/internal/vmid/client.go
@@ -314,3 +314,18 @@ func (c *Client) Healthy() bool {
 	defer resp.Body.Close()
 	return resp.StatusCode == 200
 }
+
+// SetAgentConfig updates a VM's agent-config in the vmid registry.
+func (c *Client) SetAgentConfig(vmID string, cfg json.RawMessage) error {
+	req, _ := http.NewRequest("PUT", "http://localhost/internal/vms/"+vmID+"/agent-config", bytes.NewReader(cfg))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("vmid set agent-config: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("vmid set agent-config: status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/orchestrator/internal/api/handlers.go
+++ b/orchestrator/internal/api/handlers.go
@@ -268,6 +268,7 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/vms/{name}/projects", h.handleVMAddProject)
 	mux.HandleFunc("DELETE /api/vms/{name}/projects/{project...}", h.handleVMRemoveProject)
 	mux.HandleFunc("GET /api/vms/{name}/projects", h.handleVMListProjects)
+	mux.HandleFunc("PUT /api/vms/{name}/agent-config", h.handleVMUpdateAgentConfig)
 
 	// Golden images
 	mux.HandleFunc("GET /api/golden", h.handleGoldenList)
@@ -395,18 +396,19 @@ func (h *Handler) handleNodeGet(w http.ResponseWriter, r *http.Request) {
 // --- VM handlers ---
 
 type vmCreateRequest struct {
-	Name             string            `json:"name"`
-	Type             string            `json:"type,omitempty"`
-	Description      string            `json:"description,omitempty"`
-	VCPU             int               `json:"vcpu,omitempty"`
-	RAMMIB           int               `json:"ram_mib,omitempty"`
-	Disk             string            `json:"disk,omitempty"`
-	CloneURL         string            `json:"clone_url,omitempty"`
-	CloneURLs        []string          `json:"clone_urls,omitempty"`
-	Mode             string            `json:"mode,omitempty"`
-	NodeID           string            `json:"node_id,omitempty"`
-	TailscaleAuthkey string            `json:"tailscale_authkey,omitempty"`
-	Labels           map[string]string `json:"labels,omitempty"`
+	Name             string                 `json:"name"`
+	Type             string                 `json:"type,omitempty"`
+	Description      string                 `json:"description,omitempty"`
+	VCPU             int                    `json:"vcpu,omitempty"`
+	RAMMIB           int                    `json:"ram_mib,omitempty"`
+	Disk             string                 `json:"disk,omitempty"`
+	CloneURL         string                 `json:"clone_url,omitempty"`
+	CloneURLs        []string               `json:"clone_urls,omitempty"`
+	Mode             string                 `json:"mode,omitempty"`
+	NodeID           string                 `json:"node_id,omitempty"`
+	TailscaleAuthkey string                 `json:"tailscale_authkey,omitempty"`
+	Labels           map[string]string      `json:"labels,omitempty"`
+	AgentConfig      map[string]interface{} `json:"agent_config,omitempty"`
 }
 
 // nodeToScheduler converts a state.Node to the db.Node type used by the scheduler.
@@ -553,6 +555,7 @@ func (h *Handler) handleVMCreate(w http.ResponseWriter, r *http.Request) {
 			Mode:             req.Mode,
 			AuthorizedKeys:   sshKeys,
 			TailscaleAuthkey: req.TailscaleAuthkey,
+			AgentConfig:      req.AgentConfig,
 		}, func(evt *node.ProgressEvent) {
 			line, _ := json.Marshal(evt)
 			fmt.Fprintf(w, "%s\n", line)
@@ -801,6 +804,42 @@ func (h *Handler) handleVMUpdate(w http.ResponseWriter, r *http.Request) {
 	defer resp.Body.Close()
 
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
+	io.Copy(w, resp.Body)
+}
+
+// handleVMUpdateAgentConfig forwards an agent-config update to the VM's node.
+func (h *Handler) handleVMUpdateAgentConfig(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if name == "" {
+		name = extractName(r.URL.Path, "/api/vms/")
+	}
+
+	vm := h.state.GetVM(name)
+	if vm == nil {
+		http.Error(w, "VM not found", http.StatusNotFound)
+		return
+	}
+
+	n := h.state.GetNode(vm.NodeID)
+	if n == nil {
+		http.Error(w, "node not found", http.StatusNotFound)
+		return
+	}
+
+	body, _ := io.ReadAll(r.Body)
+	url := fmt.Sprintf("http://%s/api/vms/%s/agent-config", n.APIAddr, name)
+	req, _ := http.NewRequest("PUT", url, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		http.Error(w, "node unreachable: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
 	w.WriteHeader(resp.StatusCode)
 	io.Copy(w, resp.Body)
 }

--- a/orchestrator/internal/node/client.go
+++ b/orchestrator/internal/node/client.go
@@ -26,17 +26,18 @@ func NewClient(apiAddr string) *Client {
 }
 
 type CreateRequest struct {
-	Name             string   `json:"name"`
-	Type             string   `json:"type,omitempty"`        // "firecracker" (default) or "qemu"
-	Description      string   `json:"description,omitempty"` // user-provided description
-	VCPU             int      `json:"vcpu,omitempty"`
-	RAMMIB           int      `json:"ram_mib,omitempty"`
-	Disk             string   `json:"disk,omitempty"`
-	CloneURL         string   `json:"clone_url,omitempty"`
-	CloneURLs        []string `json:"clone_urls,omitempty"`
-	Mode             string   `json:"mode,omitempty"`
-	AuthorizedKeys   []string `json:"authorized_keys,omitempty"`
-	TailscaleAuthkey string   `json:"tailscale_authkey,omitempty"`
+	Name             string                 `json:"name"`
+	Type             string                 `json:"type,omitempty"`         // "firecracker" (default) or "qemu"
+	Description      string                 `json:"description,omitempty"` // user-provided description
+	VCPU             int                    `json:"vcpu,omitempty"`
+	RAMMIB           int                    `json:"ram_mib,omitempty"`
+	Disk             string                 `json:"disk,omitempty"`
+	CloneURL         string                 `json:"clone_url,omitempty"`
+	CloneURLs        []string               `json:"clone_urls,omitempty"`
+	Mode             string                 `json:"mode,omitempty"`
+	AuthorizedKeys   []string               `json:"authorized_keys,omitempty"`
+	TailscaleAuthkey string                 `json:"tailscale_authkey,omitempty"`
+	AgentConfig      map[string]interface{} `json:"agent_config,omitempty"`
 }
 
 type CreateResponse struct {
@@ -634,6 +635,23 @@ func (c *FastClient) GetAllActivity() []TapegunVMActivity {
 	var activity []TapegunVMActivity
 	json.NewDecoder(resp.Body).Decode(&activity)
 	return activity
+}
+
+// UpdateAgentConfig pushes a new agent-config to a running VM via the node agent.
+func (c *Client) UpdateAgentConfig(vmName string, cfg map[string]interface{}) error {
+	body, _ := json.Marshal(cfg)
+	req, _ := http.NewRequest("PUT", c.baseURL+"/api/vms/"+vmName+"/agent-config", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("update agent-config: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		errBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("update agent-config: %s", string(errBody))
+	}
+	return nil
 }
 
 // SendTapegunMessage sends a message to a specific VM on the node.

--- a/orchestrator/internal/ssh/handler.go
+++ b/orchestrator/internal/ssh/handler.go
@@ -978,12 +978,20 @@ func (h *Handler) teamApply(args []string) int {
 		}
 	}
 
-	// Compute diff
+	// Build agent lookup by name
+	agentByName := make(map[string]team.ResolvedAgent)
+	for _, a := range agents {
+		agentByName[a.VMName] = a
+	}
+
+	// Compute diff: create, update, or ok
 	var toCreate []team.ResolvedAgent
+	var toUpdate []team.ResolvedAgent
 	var existing []string
 	for _, a := range agents {
 		if existingVMs[a.VMName] {
 			existing = append(existing, a.VMName)
+			toUpdate = append(toUpdate, a)
 		} else {
 			toCreate = append(toCreate, a)
 		}
@@ -1009,22 +1017,36 @@ func (h *Handler) teamApply(args []string) int {
 	// Destroy highest-indexed first
 	sort.Sort(sort.Reverse(sort.StringSlice(toDestroy)))
 
-	// Report plan
-	for _, name := range existing {
-		fmt.Printf("  ok       %s\n", name)
+	// Update existing VMs: push agent-config changes
+	updated := 0
+	for _, a := range toUpdate {
+		agentCfg := a.AgentConfigJSON(ts.Metadata.Name)
+		cfgJSON, _ := json.Marshal(agentCfg)
+
+		// Push updated agent-config to the VM's node via orchestrator API
+		fmt.Printf("  update   %s ...", a.VMName)
+		_, err := h.put("/api/vms/"+a.VMName+"/agent-config", cfgJSON)
+		if err != nil {
+			fmt.Printf(" FAILED: %v\n", err)
+			continue
+		}
+		fmt.Printf(" ok\n")
+		updated++
 	}
 
 	// Create new VMs
 	created := 0
 	for _, a := range toCreate {
+		agentCfg := a.AgentConfigJSON(ts.Metadata.Name)
 		body := map[string]interface{}{
-			"name":    a.VMName,
-			"type":    a.Type,
-			"vcpu":    a.VCPU,
-			"ram_mib": a.RAMMiB(),
-			"disk":    a.Disk,
-			"mode":    a.Mode,
-			"labels":  a.Labels(ts.Metadata.Name),
+			"name":         a.VMName,
+			"type":         a.Type,
+			"vcpu":         a.VCPU,
+			"ram_mib":      a.RAMMiB(),
+			"disk":         a.Disk,
+			"mode":         a.Mode,
+			"labels":       a.Labels(ts.Metadata.Name),
+			"agent_config": agentCfg,
 		}
 		if a.Description != "" {
 			body["description"] = a.Description
@@ -1061,7 +1083,7 @@ func (h *Handler) teamApply(args []string) int {
 		destroyed++
 	}
 
-	fmt.Printf("\nResult: %d created, %d existing, %d destroyed\n", created, len(existing), destroyed)
+	fmt.Printf("\nResult: %d created, %d updated, %d destroyed\n", created, updated, destroyed)
 	return 0
 }
 
@@ -1731,6 +1753,21 @@ func (h *Handler) post(path string, data interface{}) ([]byte, error) {
 
 func (h *Handler) delete(path string) ([]byte, error) {
 	req, _ := http.NewRequest("DELETE", h.apiBase+path, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("%s", strings.TrimSpace(string(body)))
+	}
+	return body, nil
+}
+
+func (h *Handler) put(path string, data []byte) ([]byte, error) {
+	req, _ := http.NewRequest("PUT", h.apiBase+path, bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/orchestrator/internal/team/spec.go
+++ b/orchestrator/internal/team/spec.go
@@ -158,6 +158,45 @@ func (r *ResolvedAgent) Labels(teamName string) map[string]string {
 	return labels
 }
 
+// AgentConfigJSON builds the agent-config JSON blob sent to the vmid metadata
+// service. This is what the tapegun setup phase reads on boot to configure the
+// workspace (persona, repos, etc.).
+func (r *ResolvedAgent) AgentConfigJSON(teamName string) map[string]interface{} {
+	cfg := map[string]interface{}{
+		"team":  teamName,
+		"agent": r.AgentName,
+	}
+	if r.ReplicaNum > 0 {
+		cfg["replica_index"] = r.ReplicaNum
+	}
+	if r.Persona != nil {
+		p := map[string]interface{}{}
+		if r.Persona.Role != "" {
+			p["role"] = r.Persona.Role
+		}
+		if r.Persona.ClaudeMD != "" {
+			p["claude_md"] = r.Persona.ClaudeMD
+		}
+		if r.Persona.Instructions != "" {
+			p["instructions"] = r.Persona.Instructions
+		}
+		cfg["persona"] = p
+	}
+	if len(r.Repos) > 0 {
+		cfg["repos"] = r.Repos
+	}
+	if len(r.Access) > 0 {
+		cfg["access"] = r.Access
+	}
+	if r.Authorized {
+		cfg["authorized"] = true
+	}
+	if len(r.Tapegun) > 0 {
+		cfg["tapegun"] = r.Tapegun
+	}
+	return cfg
+}
+
 // Resolve applies defaults and expands replicas into concrete VM definitions.
 func (ts *TeamSpec) Resolve() []ResolvedAgent {
 	var out []ResolvedAgent


### PR DESCRIPTION
## Summary
- `team apply` now pushes agent-config (persona, repos, access, tapegun) to both new and existing VMs
- Builds full agent-config update pipeline: orchestrator → node agent → vmid metadata service
- Previously, re-applying team YAML silently skipped all existing VMs

## Problem

`team apply` only created and destroyed VMs. If you changed a persona, added repos, or modified tapegun config in the team YAML, existing running VMs were never updated. The only workaround was to destroy and recreate the entire team, losing in-progress work.

## Changes

**`orchestrator/internal/team/spec.go`:**
- `AgentConfigJSON(teamName)` — builds the metadata JSON blob from ResolvedAgent fields (team, agent, persona, repos, access, authorized, tapegun)

**`orchestrator/internal/ssh/handler.go`:**
- `team apply` now sends `agent_config` in the VM create request body
- `team apply` pushes agent-config updates to all existing VMs via `PUT /api/vms/{name}/agent-config`
- Added `put()` HTTP helper

**`orchestrator/internal/api/handlers.go`:**
- Added `AgentConfig` field to `vmCreateRequest`
- Forwards `agent_config` in `CreateRequest` to node agent
- New endpoint: `PUT /api/vms/{name}/agent-config` — forwards to the VM's node

**`orchestrator/internal/node/client.go`:**
- Added `AgentConfig` to `CreateRequest`
- `UpdateAgentConfig()` — sends PUT to node agent

**`node/agent/internal/api/handlers.go`:**
- New endpoint: `PUT /api/vms/{name}/agent-config` — forwards to vmid admin socket

**`node/agent/internal/vmid/client.go`:**
- `SetAgentConfig()` — sends PUT to vmid's `/internal/vms/{id}/agent-config`

## Test plan
- [ ] `team apply` with new team creates VMs with agent-config (check vmid: `curl 169.254.169.254/metadata/agent-config`)
- [ ] `team apply` with modified persona pushes update to existing VMs
- [ ] `team apply` with unchanged YAML shows "update" for all existing VMs (idempotent push)
- [ ] `team diff` still shows correct create/update/destroy counts
- [ ] Tapegun setup phase reads updated agent-config on next boot/restart
- [ ] Hardware changes (vcpu, ram) are not auto-applied (only agent-config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)