### PR TITLE
Fix #152: control plane lock — prevent concurrent instances

### DIFF
--- a/host/cmd/host/main.go
+++ b/host/cmd/host/main.go
@@ -378,6 +378,18 @@ func main() {
 func runDaemon() {
 	cfg := defaultConfig()
 
+	// Acquire exclusive lock to prevent multiple control plane instances.
+	// Two instances modifying cluster.json concurrently causes corruption.
+	lockPath := "/run/boxcutter-host.lock"
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		log.Fatalf("Cannot open lock file %s: %v", lockPath, err)
+	}
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		log.Fatalf("Another boxcutter-host instance is already running (lock: %s)", lockPath)
+	}
+	defer lockFile.Close()
+
 	log.Println("boxcutter-host starting...")
 
 	// 0. Start mosquitto broker


### PR DESCRIPTION
## Summary
- Adds `flock`-based exclusive lock at daemon startup to prevent two `boxcutter-host` instances from running simultaneously
- 12 lines of code that prevent catastrophic cluster.json corruption

## Problem

From `docs/improvement-proposal.md` (Phase 1 Safety):

> No file lock prevents multiple `boxcutter-host` instances from running simultaneously. Two control planes can modify `cluster.json` concurrently, leading to contradictory VM actions and state corruption.

This can happen when:
- `systemctl restart boxcutter-host` races with a still-running instance
- Operator accidentally runs `boxcutter-host run` manually while systemd is running it
- Binary upgrade replaces the binary but the old process hasn't fully stopped

## Changes

**`host/cmd/host/main.go`** — `runDaemon()`:
- Opens `/run/boxcutter-host.lock` with `O_CREATE|O_RDWR`
- Acquires `LOCK_EX|LOCK_NB` (exclusive, non-blocking) via `syscall.Flock`
- Second instance exits immediately: `"Another boxcutter-host instance is already running"`
- Lock auto-released on process exit (clean or crash) — no manual cleanup
- Only the daemon acquires the lock; CLI commands (`status`, `stop-node`, `upgrade`) are unaffected

## Test plan
- [ ] First `boxcutter-host run` starts normally
- [ ] Second `boxcutter-host run` exits with lock error message
- [ ] After first instance stops, second can start
- [ ] After first instance crashes (kill -9), second can start (lock auto-released)
- [ ] CLI commands work while daemon is running
- [ ] `systemctl restart boxcutter-host` works cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)