### PR TITLE
Fix #154: migration timeout — prevent zombie VMs on network failure

### DIFF
--- a/node/agent/internal/api/handlers.go
+++ b/node/agent/internal/api/handlers.go
@@ -524,15 +524,29 @@ func (h *Handler) handleMigrate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Start migration in background — caller polls GET /api/vms/{name} for status
+	// Start migration in background — caller polls GET /api/vms/{name} for status.
+	// Issue #154: 5-minute timeout prevents zombie VMs on network failure.
 	go func() {
-		// Use defer to guarantee cleanup even if MigrateVM panics.
-		// EndMigration clears both in-memory set and filesystem marker.
-		// On success, MigrateVM already removed vmDir, so SetMigrating is a no-op.
 		defer h.mgr.EndMigration(name)
-		_, err := h.mgr.MigrateVM(name, req.TargetAddr, req.TargetBridgeIP)
-		if err != nil {
-			log.Printf("Migration failed for %s: %v", name, err)
+
+		done := make(chan error, 1)
+		go func() {
+			_, err := h.mgr.MigrateVM(name, req.TargetAddr, req.TargetBridgeIP)
+			done <- err
+		}()
+
+		select {
+		case err := <-done:
+			if err != nil {
+				log.Printf("Migration failed for %s: %v", name, err)
+			}
+		case <-time.After(5 * time.Minute):
+			log.Printf("ALERT: Migration timeout for %s after 5 minutes — clearing migration marker", name)
+			log.Printf("The VM may need manual restart: the source may be paused/stopped and the target may have partial state.")
+			// EndMigration (deferred) clears the in-memory and filesystem
+			// migration markers so the VM is no longer stuck in "migrating" state.
+			// The underlying rsync/scp may still be running — it will fail
+			// harmlessly once the SSH control socket is cleaned up.
 		}
 	}()
 


### PR DESCRIPTION
## Summary
- Adds 5-minute timeout on VM migration to prevent zombie VMs when network fails mid-transfer
- On timeout, clears migration marker so the VM is no longer stuck in "migrating" state

## Problem

From `docs/improvement-proposal.md` (Phase 1 Safety):

> No timeout on VM migration. If network fails mid-transfer, VM stays in "migrating" state forever with no rollback.

When this happens:
- Source VM is paused (FC) or stopped (QEMU) — unresponsive to users
- Target has partial snapshot files — wasted disk
- Health monitor and drain logic skip "migrating" VMs — invisible to the system
- Only manual intervention (clear migration marker, restart VM) recovers

## Changes

**`node/agent/internal/api/handlers.go`** — `handleMigrate()`:

The migration goroutine now wraps `MigrateVM()` in a select with a 5-minute timeout:

```go
select {
case err := <-done:
    // Normal path: migration completed (success or failure)
case <-time.After(5 * time.Minute):
    // Timeout: clear migration marker, log alert
}
```

On timeout:
- `EndMigration()` (deferred) clears the in-memory and filesystem migration markers
- VM exits "migrating" status — becomes visible to health monitor and drain
- ALERT-level log for operator visibility
- Source VM may need manual restart (paused/stopped state), but is no longer invisible

The underlying rsync/scp may still be running after timeout but fails harmlessly once the SSH control socket is cleaned up.

## Why 5 minutes?

- Typical FC snapshot migration: 10-30s (RAM + rootfs delta)
- Large QEMU VM migration: 1-3 minutes (up to 12G RAM)
- 5 minutes is 2-3x the worst case — generous enough to avoid false timeouts
- Network failures typically manifest within seconds (connection refused) or hang indefinitely (packet loss) — the timeout catches the latter

## Test plan
- [ ] Normal migration completes within timeout (no change in behavior)
- [ ] Migration with unreachable target times out after 5 minutes
- [ ] After timeout, VM status is no longer "migrating"
- [ ] After timeout, health monitor can see and manage the VM
- [ ] ALERT log message appears on timeout
- [ ] Drain that includes a timed-out migration continues with remaining VMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)