### PR TITLE
Fix #157: check runtime deps at startup with clear install instructions

### DIFF
--- a/host/cmd/host/main.go
+++ b/host/cmd/host/main.go
@@ -376,6 +376,8 @@ func main() {
 }
 
 func runDaemon() {
+	checkRuntimeDeps()
+
 	cfg := defaultConfig()
 
 	// Acquire exclusive lock to prevent multiple control plane instances.
@@ -5067,7 +5069,58 @@ func ensureBaseImage(cfg HostConfig, vmType string, tag string) (string, *oci.Im
 	return basePath, meta, nil
 }
 
+// checkRuntimeDeps verifies that required external tools are installed.
+// Called early in bootstrap and daemon startup to fail fast with clear
+// instructions instead of cryptic "exit 127" errors mid-operation.
+func checkRuntimeDeps() {
+	required := []struct {
+		binary  string
+		pkg     string // apt package that provides it
+		purpose string
+	}{
+		{"qemu-system-x86_64", "qemu-system-x86", "launching VMs"},
+		{"qemu-img", "qemu-utils", "creating and managing VM disks"},
+		{"genisoimage", "genisoimage", "creating cloud-init ISOs"},
+		{"mosquitto", "mosquitto", "MQTT broker for golden image distribution"},
+		{"iptables", "iptables", "NAT and firewall rules"},
+		{"ip", "iproute2", "bridge and network configuration"},
+		{"zstd", "zstd", "decompressing OCI images"},
+		{"mksquashfs", "squashfs-tools", "building tools.img for VMs"},
+		{"ssh", "openssh-client", "node VM management"},
+		{"scp", "openssh-client", "file transfer to nodes"},
+	}
+
+	var missing []struct{ binary, pkg, purpose string }
+	for _, dep := range required {
+		if _, err := exec.LookPath(dep.binary); err != nil {
+			missing = append(missing, dep)
+		}
+	}
+
+	if len(missing) > 0 {
+		log.Println("ERROR: Missing required runtime dependencies:")
+		for _, m := range missing {
+			log.Printf("  - %s (%s) — needed for %s", m.binary, m.pkg, m.purpose)
+		}
+		// Deduplicate package names for the install command
+		pkgSet := make(map[string]bool)
+		for _, m := range missing {
+			pkgSet[m.pkg] = true
+		}
+		var pkgs []string
+		for p := range pkgSet {
+			pkgs = append(pkgs, p)
+		}
+		sort.Strings(pkgs)
+		log.Printf("")
+		log.Printf("Install with: sudo apt-get install -y %s", strings.Join(pkgs, " "))
+		log.Fatalf("Bootstrap aborted: missing %d runtime dependencies", len(missing))
+	}
+}
+
 func runBootstrap() {
+	checkRuntimeDeps()
+
 	cfg := defaultConfig()
 	os.MkdirAll(cfg.ImagesDir, 0755)
 

--- a/host/debian/control
+++ b/host/debian/control
@@ -3,7 +3,7 @@ Version: VERSION_PLACEHOLDER
 Section: admin
 Priority: optional
 Architecture: amd64
-Depends: qemu-system-x86, qemu-utils, genisoimage, mosquitto, iptables, iproute2, zstd
+Depends: qemu-system-x86, qemu-utils, genisoimage, mosquitto, iptables, iproute2, zstd, squashfs-tools, openssh-client
 Maintainer: Andrew Budd <andrew@boxcutter.dev>
 Description: Boxcutter host control plane
  Manages QEMU VMs (orchestrator + nodes) on bare metal hosts.


### PR DESCRIPTION
## Summary

- Adds `checkRuntimeDeps()` that runs at the start of both `bootstrap` and `run` commands, verifying all required external tools are installed
- On failure, prints each missing tool with its apt package name and purpose, plus a ready-to-copy `apt-get install` command
- Adds `squashfs-tools` and `openssh-client` to the deb package `Depends` field

## Example output

```
ERROR: Missing required runtime dependencies:
  - mksquashfs (squashfs-tools) — needed for building tools.img for VMs
  - mosquitto (mosquitto) — needed for MQTT broker for golden image distribution

Install with: sudo apt-get install -y mosquitto squashfs-tools
Bootstrap aborted: missing 2 runtime dependencies
```

## Tools checked

| Binary | Package | Purpose |
|--------|---------|---------|
| qemu-system-x86_64 | qemu-system-x86 | Launching VMs |
| qemu-img | qemu-utils | Disk management |
| genisoimage | genisoimage | Cloud-init ISOs |
| mosquitto | mosquitto | MQTT broker |
| iptables | iptables | NAT/firewall |
| ip | iproute2 | Bridge/network config |
| zstd | zstd | OCI decompression |
| mksquashfs | squashfs-tools | Building tools.img |
| ssh/scp | openssh-client | Node management |

## Test plan

- [ ] `boxcutter-host bootstrap` on fresh Ubuntu 24.04 without deps → clear error with install command
- [ ] After installing deps → bootstrap proceeds normally
- [ ] `boxcutter-host run` also checks deps before starting daemon
- [ ] deb package installs all dependencies automatically

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)