### PR TITLE
Fix #160: delay Enter after multi-line paste in tapegun sendkeys

### DIFF
--- a/node/golden/config/boxcutter-tapegun
+++ b/node/golden/config/boxcutter-tapegun
@@ -686,6 +686,12 @@ print(json.dumps({'pane_content': sys.stdin.read(), 'status': '$STATUS'}))" <<< 
                 if [ -n "$line" ]; then
                     if [ "$no_enter" = "true" ]; then
                         $TMUX_CMD send-keys -t 0 "$line"
+                    elif case "$line" in *$'\n'*) true ;; *) false ;; esac; then
+                        # Multi-line: send text first, then Enter separately
+                        # after a delay so Claude Code processes the paste.
+                        $TMUX_CMD send-keys -t 0 "$line"
+                        sleep 0.5
+                        $TMUX_CMD send-keys -t 0 Enter
                     else
                         $TMUX_CMD send-keys -t 0 "$line" Enter
                     fi


### PR DESCRIPTION
## Summary

- Fixes multi-line `tapegun sendkeys` auto-submit: when Claude Code detects a paste (`[Pasted text #N +M lines]`), it waits for manual Enter — but the old code sent Enter as part of the paste buffer
- For multi-line messages, now sends text first, waits 500ms for paste processing, then sends Enter separately
- Single-line messages and `--no-enter` behavior are unchanged

## Test plan

- [ ] Single-line sendkeys: still auto-submits immediately (no behavior change)
- [ ] Multi-line sendkeys: auto-submits after paste is processed (500ms delay + separate Enter)
- [ ] `--no-enter` flag: still prevents submission for both single and multi-line messages
- [ ] Bash syntax check passes (`bash -n boxcutter-tapegun`)

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)