### PR TITLE
team apply: wait for node capacity instead of failing

### DIFF
--- a/orchestrator/internal/ssh/capacity_wait_test.go
+++ b/orchestrator/internal/ssh/capacity_wait_test.go
@@ -1,0 +1,26 @@
+package ssh
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsCapacityError(t *testing.T) {
+	tests := []struct {
+		err  string
+		want bool
+	}{
+		{"all nodes failed", true},
+		{"no active nodes", true},
+		{"no reachable nodes", true},
+		{"VM 'foo' already exists", false},
+		{"connection refused", false},
+		{"invalid JSON: unexpected EOF", false},
+	}
+	for _, tt := range tests {
+		got := isCapacityError(fmt.Errorf("%s", tt.err))
+		if got != tt.want {
+			t.Errorf("isCapacityError(%q) = %v, want %v", tt.err, got, tt.want)
+		}
+	}
+}

--- a/orchestrator/internal/ssh/capacity_wait_test.go
+++ b/orchestrator/internal/ssh/capacity_wait_test.go
@@ -2,6 +2,8 @@ package ssh
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -22,5 +24,48 @@ func TestIsCapacityError(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("isCapacityError(%q) = %v, want %v", tt.err, got, tt.want)
 		}
+	}
+}
+
+func TestPostStreamSurfacesHTTPErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantErr    string
+	}{
+		{
+			name:       "no active nodes (pre-stream 503)",
+			statusCode: http.StatusServiceUnavailable,
+			body:       "no active nodes\n",
+			wantErr:    "no active nodes",
+		},
+		{
+			name:       "no reachable nodes (pre-stream 503)",
+			statusCode: http.StatusServiceUnavailable,
+			body:       "no reachable nodes\n",
+			wantErr:    "no reachable nodes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, tt.body, tt.statusCode)
+			}))
+			defer srv.Close()
+
+			h := &Handler{apiBase: srv.URL}
+			_, err := h.postStream("/api/vms", nil, nil)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if err.Error() != tt.wantErr {
+				t.Errorf("postStream error = %q, want %q", err.Error(), tt.wantErr)
+			}
+			if !isCapacityError(err) {
+				t.Errorf("isCapacityError(%q) = false, want true", err.Error())
+			}
+		})
 	}
 }

--- a/orchestrator/internal/ssh/handler.go
+++ b/orchestrator/internal/ssh/handler.go
@@ -2107,6 +2107,11 @@ func (h *Handler) postStream(path string, data interface{}, onProgress func(map[
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode >= 400 {
+		errBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("%s", strings.TrimSpace(string(errBody)))
+	}
+
 	decoder := json.NewDecoder(resp.Body)
 	var last map[string]interface{}
 	for decoder.More() {

--- a/orchestrator/internal/ssh/handler.go
+++ b/orchestrator/internal/ssh/handler.go
@@ -1110,7 +1110,11 @@ func (h *Handler) teamApply(args []string) int {
 		updated++
 	}
 
-	// Create new VMs
+	// Create new VMs, waiting for node capacity when necessary.
+	const (
+		capacityPollInterval = 10 * time.Second
+		capacityTimeout      = 5 * time.Minute
+	)
 	created := 0
 	for _, a := range toCreate {
 		agentCfg := a.AgentConfig(ts.Metadata.Name, allPersonaFiles)
@@ -1137,15 +1141,26 @@ func (h *Handler) teamApply(args []string) int {
 		}
 
 		fmt.Printf("  create   %s ...", a.VMName)
-		_, err := h.postStream("/api/vms", body, func(evt map[string]interface{}) {
-			// suppress progress for batch creation
-		})
-		if err != nil {
-			fmt.Printf(" FAILED: %v\n", err)
-			continue
+		deadline := time.Now().Add(capacityTimeout)
+		var lastErr error
+		for {
+			_, err := h.postStream("/api/vms", body, func(evt map[string]interface{}) {
+				// suppress progress for batch creation
+			})
+			if err == nil {
+				fmt.Printf(" ok\n")
+				created++
+				break
+			}
+			lastErr = err
+			if !isCapacityError(err) || time.Now().After(deadline) {
+				fmt.Printf(" FAILED: %v\n", lastErr)
+				break
+			}
+			fmt.Printf(" waiting for capacity (retry in 10s)\n")
+			time.Sleep(capacityPollInterval)
+			fmt.Printf("  create   %s ...", a.VMName)
 		}
-		fmt.Printf(" ok\n")
-		created++
 	}
 
 	// Destroy scale-down VMs
@@ -1163,6 +1178,15 @@ func (h *Handler) teamApply(args []string) int {
 
 	fmt.Printf("\nResult: %d created, %d updated, %d unchanged, %d destroyed\n", created, updated, len(unchanged), destroyed)
 	return 0
+}
+
+// isCapacityError returns true if the error indicates no node has capacity,
+// meaning a retry after auto-scaler adds nodes may succeed.
+func isCapacityError(err error) bool {
+	msg := err.Error()
+	return msg == "all nodes failed" ||
+		msg == "no active nodes" ||
+		msg == "no reachable nodes"
 }
 
 func (h *Handler) teamDiff(args []string) int {


### PR DESCRIPTION
## Summary
- When `team apply` creates VMs and no node has capacity, it now polls every 10s for up to 5 minutes instead of failing immediately with "all nodes failed"
- Only capacity-related errors (`all nodes failed`, `no active nodes`, `no reachable nodes`) trigger the retry loop — other errors fail immediately
- Adds `isCapacityError` helper with unit tests

Fixes #162

## Test plan
- [ ] Unit test for `isCapacityError` covers all three capacity error strings plus non-capacity errors
- [ ] Integration: run `team apply` with a team spec requiring more nodes than currently available — verify it waits and succeeds after auto-scaler adds capacity
- [ ] Verify non-capacity errors (e.g. VM name conflict, invalid config) still fail immediately without retrying

🤖 Generated with [Claude Code](https://claude.com/claude-code)