### PR TITLE
Fix drain-first to stop QEMU when no VMs need migration

### DIFF
--- a/host/cmd/host/main.go
+++ b/host/cmd/host/main.go
@@ -2249,7 +2249,20 @@ func drainNode(cfg HostConfig, state *cluster.State, nodeID string) {
 	}
 
 	if len(toMigrate) == 0 {
-		log.Printf("Drain: all VMs already migrated from %s", nodeID)
+		log.Printf("Drain: no VMs to migrate from %s (all stopped or already migrated), stopping node", nodeID)
+		// Clear drain target tracking on success
+		if goal := state.UpgradeGoal; goal != nil {
+			goal.DrainTargetNodeID = ""
+		}
+		state.RemoveNode(nodeID)
+		state.Save()
+		qemu.Stop(nodeID, node.PID)
+		if node.TAP != "" {
+			bridge.DeleteTAP(node.TAP)
+		}
+		cleanupNodeArtifacts(cfg, nodeID)
+		log.Printf("Drain: %s complete (no migratable VMs)", nodeID)
+		return
 	} else {
 		// QEMU VMs now support live migration via QMP state save/restore.
 		// No need to stop them before drain — the node agent handles it.


### PR DESCRIPTION
## Summary
- When `drainNode` finds VMs on a node but none need migration (all stopped or already migrated to target), it now stops the QEMU process, removes the node from state, and cleans up artifacts — matching the existing empty-node path
- Previously this case fell through to migration batches (no-op) then the safety check, which refused to stop the node because stopped VMs weren't on the target, causing the reconciler to loop forever
- Also clears `DrainTargetNodeID` on the upgrade goal so the reconciler doesn't reference the removed node

Fixes #161

## Test plan
- [ ] **Test 1 (golden path):** Trigger drain-first upgrade with insufficient RAM for side-by-side. Verify drained node's QEMU process is killed, RAM is freed, replacement launches
- [ ] **Test 2 (stopped VMs):** Node has stopped VMs only. Verify drain completes and QEMU stops without attempting migration
- [ ] **Test 3 (already migrated):** Node's VMs already exist on target from previous drain attempt. Verify QEMU stops immediately
- [ ] **Test 4 (loop resolution):** Verify reconciler does NOT loop forever — after drain, `getAvailableMemoryMB()` returns enough for replacement
- [ ] **Test 5 (running VMs still migrate):** Node with running VMs still goes through normal migration flow (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)