### PR TITLE
Fix #174: tools.img not mounted on QEMU VMs

### DIFF
--- a/host/cmd/host/main.go
+++ b/host/cmd/host/main.go
@@ -1835,6 +1835,25 @@ func deployNodeBinary(cfg HostConfig, bridgeIP, nodeID string) error {
 	}
 	log.Printf("Deploy %s: %d VMs running before restart", nodeID, preRestartVMs)
 
+	// Deploy tools.img if present on host (needed for QEMU VMs to have tapegun daemon)
+	toolsImgPath := "/var/lib/boxcutter/tools.img"
+	if fileExists(toolsImgPath) {
+		scpTools := exec.Command("scp", append(sshOpts, toolsImgPath, "ubuntu@"+bridgeIP+":/tmp/tools.img")...)
+		if out, err := scpTools.CombinedOutput(); err != nil {
+			log.Printf("Deploy %s: tools.img SCP failed (non-fatal): %v\n%s", nodeID, err, string(out))
+		} else {
+			mvTools := exec.Command("ssh", append(sshOpts, "ubuntu@"+bridgeIP,
+				"sudo", "mv", "/tmp/tools.img", "/var/lib/boxcutter/tools.img")...)
+			if out, err := mvTools.CombinedOutput(); err != nil {
+				log.Printf("Deploy %s: tools.img install failed (non-fatal): %v\n%s", nodeID, err, string(out))
+			} else {
+				log.Printf("Deploy %s: tools.img deployed successfully", nodeID)
+			}
+		}
+	} else {
+		log.Printf("Deploy %s: tools.img not found at %s on host — skipping", nodeID, toolsImgPath)
+	}
+
 	// Install and restart
 	installCmd := exec.Command("ssh", append(sshOpts, "ubuntu@"+bridgeIP,
 		"sudo", "mv", "/tmp/boxcutter-node", "/usr/local/bin/boxcutter-node",

--- a/node/agent/internal/vm/manager.go
+++ b/node/agent/internal/vm/manager.go
@@ -1075,22 +1075,27 @@ func (m *Manager) Health() map[string]interface{} {
 		}
 	}
 
+	// Check if tools.img is present (required for QEMU VMs)
+	_, toolsErr := os.Stat(toolsImagePath)
+	toolsImgPresent := toolsErr == nil
+
 	return map[string]interface{}{
-		"hostname":          hostname,
-		"vcpu_total":        cpuCount,
-		"vcpu_allocated":    allocatedVCPU,
-		"ram_total_mib":     sysRAM,
-		"ram_allocated_mib": totalRAM,
-		"ram_available_mib": availRAM,
-		"ram_free_mib":      sysRAM - totalRAM,
-		"disk_total_mb":     diskTotalMB,
-		"disk_used_mb":      diskUsedMB,
-		"disk_vms_mb":       diskVMsMB,
-		"vms_total":         len(vms),
-		"vms_running":       running,
-		"golden_ready":      goldenReady,
-		"qemu_version":      qemuVersion,
-		"status":            "active",
+		"hostname":           hostname,
+		"vcpu_total":         cpuCount,
+		"vcpu_allocated":     allocatedVCPU,
+		"ram_total_mib":      sysRAM,
+		"ram_allocated_mib":  totalRAM,
+		"ram_available_mib":  availRAM,
+		"ram_free_mib":       sysRAM - totalRAM,
+		"disk_total_mb":      diskTotalMB,
+		"disk_used_mb":       diskUsedMB,
+		"disk_vms_mb":        diskVMsMB,
+		"vms_total":          len(vms),
+		"vms_running":        running,
+		"golden_ready":       goldenReady,
+		"qemu_version":       qemuVersion,
+		"tools_img_present":  toolsImgPresent,
+		"status":             "active",
 	}
 }
 

--- a/node/agent/internal/vm/qemu.go
+++ b/node/agent/internal/vm/qemu.go
@@ -135,12 +135,11 @@ func launchQEMU(vmDir string, st *VMState) (int, error) {
 	}
 
 	// Attach tools image (read-only squashfs with boxcutter CLI)
-	if _, err := os.Stat(toolsImagePath); err == nil {
-		args = append(args, "-drive", fmt.Sprintf("file=%s,format=raw,if=virtio,readonly=on", toolsImagePath))
-		log.Printf("QEMU VM %s: attached tools.img as /dev/vdb", st.Name)
-	} else {
-		log.Printf("WARNING: tools.img not found at %s — VMs will lack /opt/boxcutter/tools", toolsImagePath)
+	if _, err := os.Stat(toolsImagePath); err != nil {
+		return 0, fmt.Errorf("tools.img not found at %s: %w (QEMU VMs require tools.img for tapegun daemon)", toolsImagePath, err)
 	}
+	args = append(args, "-drive", fmt.Sprintf("file=%s,format=raw,if=virtio,readonly=on", toolsImagePath))
+	log.Printf("QEMU VM %s: attached tools.img as /dev/vdb", st.Name)
 
 	log.Printf("Launching QEMU VM %s: kernel=%s initrd=%s vcpu=%d ram=%dMiB",
 		st.Name, kernel, initrd, st.VCPU, st.RAMMIB)

--- a/node/agent/internal/vm/qemu_test.go
+++ b/node/agent/internal/vm/qemu_test.go
@@ -1,0 +1,77 @@
+package vm
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLaunchQEMU_MissingToolsImg verifies that launchQEMU returns an error
+// when tools.img is not present at the expected path. This is a regression
+// test for issue #174 where missing tools.img was only a warning, causing
+// QEMU VMs to launch without the tapegun daemon.
+func TestLaunchQEMU_MissingToolsImg(t *testing.T) {
+	// toolsImagePath is /var/lib/boxcutter/tools.img — skip if it exists
+	// (e.g. on a real node), since we want to test the missing case.
+	if _, err := os.Stat(toolsImagePath); err == nil {
+		t.Skip("tools.img exists on this host; cannot test missing-tools-img path")
+	}
+
+	// Create a temp VM directory with a fake kernel so localKernel() succeeds.
+	vmDir := t.TempDir()
+	fakeKernel := filepath.Join(vmDir, "vmlinuz")
+	if err := os.WriteFile(fakeKernel, []byte("fake-kernel"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	st := &VMState{
+		Name:   "test-vm",
+		VCPU:   1,
+		RAMMIB: 256,
+		TAP:    "tap-test",
+		MAC:    "AA:FC:00:00:00:99",
+	}
+
+	_, err := launchQEMU(vmDir, st)
+	if err == nil {
+		t.Fatal("expected launchQEMU to fail when tools.img is missing, but it succeeded")
+	}
+	if !strings.Contains(err.Error(), "tools.img") {
+		t.Fatalf("expected error to mention tools.img, got: %v", err)
+	}
+}
+
+// TestLaunchQEMUIncoming_MissingToolsImg verifies that launchQEMUIncoming
+// returns an error when tools.img is missing.
+func TestLaunchQEMUIncoming_MissingToolsImg(t *testing.T) {
+	if _, err := os.Stat(toolsImagePath); err == nil {
+		t.Skip("tools.img exists on this host; cannot test missing-tools-img path")
+	}
+
+	vmDir := t.TempDir()
+	fakeKernel := filepath.Join(vmDir, "vmlinuz")
+	if err := os.WriteFile(fakeKernel, []byte("fake-kernel"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// launchQEMUIncoming expects a rootfs file
+	if err := os.WriteFile(filepath.Join(vmDir, "rootfs.ext4"), []byte("fake"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	st := &VMState{
+		Name:   "test-vm",
+		VCPU:   1,
+		RAMMIB: 256,
+		TAP:    "tap-test",
+		MAC:    "AA:FC:00:00:00:99",
+	}
+
+	_, err := launchQEMUIncoming(vmDir, st)
+	if err == nil {
+		t.Fatal("expected launchQEMUIncoming to fail when tools.img is missing, but it succeeded")
+	}
+	if !strings.Contains(err.Error(), "tools.img") {
+		t.Fatalf("expected error to mention tools.img, got: %v", err)
+	}
+}

--- a/node/agent/internal/vm/qmpapi.go
+++ b/node/agent/internal/vm/qmpapi.go
@@ -321,9 +321,10 @@ func launchQEMUIncoming(vmDir string, st *VMState) (int, error) {
 	}
 
 	// Attach tools.img — must match source VM's device topology for migration.
-	if _, err := os.Stat(toolsImagePath); err == nil {
-		args = append(args, "-drive", fmt.Sprintf("file=%s,format=raw,if=virtio,readonly=on", toolsImagePath))
+	if _, err := os.Stat(toolsImagePath); err != nil {
+		return 0, fmt.Errorf("tools.img not found at %s: %w (QEMU VMs require tools.img for tapegun daemon)", toolsImagePath, err)
 	}
+	args = append(args, "-drive", fmt.Sprintf("file=%s,format=raw,if=virtio,readonly=on", toolsImagePath))
 
 	log.Printf("Launching QEMU VM %s (incoming migration mode)", st.Name)
 
@@ -441,10 +442,11 @@ func launchQEMUIncomingTCP(vmDir string, st *VMState) (int, int, error) {
 	// Attach tools.img — must match source VM's device topology for live migration.
 	// QEMU rejects incoming migration if the target has fewer virtio drives than
 	// the source, causing silent fallback to stop+relocate.
-	if _, err := os.Stat(toolsImagePath); err == nil {
-		args = append(args, "-drive", fmt.Sprintf("file=%s,format=raw,if=virtio,readonly=on", toolsImagePath))
-		log.Printf("QEMU VM %s (incoming): attached tools.img as /dev/vdb", st.Name)
+	if _, err := os.Stat(toolsImagePath); err != nil {
+		return 0, 0, fmt.Errorf("tools.img not found at %s: %w (QEMU VMs require tools.img for tapegun daemon)", toolsImagePath, err)
 	}
+	args = append(args, "-drive", fmt.Sprintf("file=%s,format=raw,if=virtio,readonly=on", toolsImagePath))
+	log.Printf("QEMU VM %s (incoming): attached tools.img as /dev/vdb", st.Name)
 
 	log.Printf("Launching QEMU VM %s (incoming live migration on port %d)", st.Name, migratePort)
 


### PR DESCRIPTION
## Summary
- **Hard error** when tools.img is missing: `launchQEMU()`, `launchQEMUIncoming()`, and `launchQEMUIncomingTCP()` now return errors instead of silently launching broken VMs
- **Deploy tools.img to auto-scaled nodes**: `deployNodeBinary()` now SCPs tools.img alongside the node agent binary
- **Health endpoint**: Added `tools_img_present` field to `/api/health` so operators can detect affected nodes
- **Tests**: 2 new tests verifying the missing-tools-img error path

## Root Cause
`launchQEMU()` only logged a warning when `/var/lib/boxcutter/tools.img` was missing on a node. VMs launched without the tools drive, meaning no `/dev/vdb`, no `/opt/boxcutter/tools` mount, no tapegun daemon, no automated Claude Code startup.

## Test plan
- [ ] `bash host/rebuild-tools.sh --deploy 24` to fix node-24 immediately
- [ ] Restart VMs on node-24, verify `systemctl status boxcutter-tapegun` shows active
- [ ] Create a QEMU VM on a node WITHOUT tools.img — should get a clear error, not a broken VM
- [ ] Auto-scale a new node, verify tools.img is deployed alongside the binary
- [ ] Check `/api/health` on a node — should include `tools_img_present: true`

Fixes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)