### PR TITLE
Feat #176: vmid inference proxy for local GPU models

### DIFF
--- a/node/vmid/cmd/vmid/main.go
+++ b/node/vmid/cmd/vmid/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/AndrewBudd/boxcutter/node/vmid/internal/api"
 	"github.com/AndrewBudd/boxcutter/node/vmid/internal/config"
+	"github.com/AndrewBudd/boxcutter/node/vmid/internal/inference"
 	"github.com/AndrewBudd/boxcutter/node/vmid/internal/middleware"
 	"github.com/AndrewBudd/boxcutter/node/vmid/internal/registry"
 	"github.com/AndrewBudd/boxcutter/node/vmid/internal/sentinel"
@@ -110,6 +111,8 @@ func main() {
 	tapegunHandler.Register(vmMux)
 	messagingHandler := api.NewMessagingHandler(reg, cfg.Metadata.NodeAgentURL)
 	messagingHandler.Register(vmMux)
+	inferenceHandler := inference.NewHandler(cfg.Inference, reg)
+	inferenceHandler.Register(vmMux)
 
 	identityMiddleware := middleware.Identity(reg)
 

--- a/node/vmid/config.yaml.example
+++ b/node/vmid/config.yaml.example
@@ -28,3 +28,7 @@ jwt:
 log:
   level: info
   format: json
+
+# Optional: inference proxy settings for local GPU / cloud inference
+# inference:
+#   local_endpoint: "http://192.168.50.1:11434"  # Host bridge IP + Ollama port

--- a/node/vmid/internal/config/config.go
+++ b/node/vmid/internal/config/config.go
@@ -9,12 +9,18 @@ import (
 )
 
 type Config struct {
-	Listen   ListenConfig        `yaml:"listen"`
-	JWT      JWTConfig           `yaml:"jwt"`
-	GitHub   *GitHubConfig       `yaml:"github,omitempty"`
-	Policies []Policy            `yaml:"policies,omitempty"`
-	Metadata MetadataFilesConfig `yaml:"metadata"`
-	Log      LogConfig           `yaml:"log"`
+	Listen    ListenConfig        `yaml:"listen"`
+	JWT       JWTConfig           `yaml:"jwt"`
+	GitHub    *GitHubConfig       `yaml:"github,omitempty"`
+	Policies  []Policy            `yaml:"policies,omitempty"`
+	Metadata  MetadataFilesConfig `yaml:"metadata"`
+	Log       LogConfig           `yaml:"log"`
+	Inference InferenceGlobalConfig `yaml:"inference"`
+}
+
+// InferenceGlobalConfig holds node-level inference proxy settings.
+type InferenceGlobalConfig struct {
+	LocalEndpoint string `yaml:"local_endpoint"` // Ollama endpoint, e.g. "http://192.168.50.1:11434"
 }
 
 type ListenConfig struct {
@@ -133,6 +139,9 @@ func Load(path string) (*Config, error) {
 		Log: LogConfig{
 			Level:  "info",
 			Format: "json",
+		},
+		Inference: InferenceGlobalConfig{
+			LocalEndpoint: "http://192.168.50.1:11434",
 		},
 	}
 

--- a/node/vmid/internal/inference/proxy.go
+++ b/node/vmid/internal/inference/proxy.go
@@ -1,0 +1,257 @@
+package inference
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/AndrewBudd/boxcutter/node/vmid/internal/config"
+	"github.com/AndrewBudd/boxcutter/node/vmid/internal/middleware"
+	"github.com/AndrewBudd/boxcutter/node/vmid/internal/registry"
+)
+
+const (
+	providerLocal      = "local"
+	providerOpenRouter = "openrouter"
+
+	openRouterBaseURL = "https://openrouter.ai/api"
+)
+
+// Handler handles inference proxy requests for VMs.
+type Handler struct {
+	cfg config.InferenceGlobalConfig
+	reg *registry.Registry
+}
+
+// NewHandler creates a new inference proxy handler.
+func NewHandler(cfg config.InferenceGlobalConfig, reg *registry.Registry) *Handler {
+	return &Handler{cfg: cfg, reg: reg}
+}
+
+// Register adds inference routes to the mux.
+func (h *Handler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("POST /v1/chat/completions", h.handleProxy)
+	mux.HandleFunc("POST /v1/completions", h.handleProxy)
+	mux.HandleFunc("GET /v1/models", h.handleModels)
+	mux.HandleFunc("GET /inference/config", h.handleConfig)
+}
+
+// getInferenceConfig extracts the inference config for the calling VM.
+// Returns nil if the VM has no inference config or uses anthropic provider.
+func (h *Handler) getInferenceConfig(r *http.Request) (*registry.InferenceConfig, *registry.VMRecord, error) {
+	rec, ok := middleware.VMFromContext(r.Context())
+	if !ok {
+		return nil, nil, fmt.Errorf("no VM context")
+	}
+
+	if rec.AgentConfig == nil || rec.AgentConfig.Inference == nil {
+		return nil, rec, nil
+	}
+
+	inf := rec.AgentConfig.Inference
+	if inf.Provider == "anthropic" || inf.Provider == "" {
+		return nil, rec, nil
+	}
+
+	return inf, rec, nil
+}
+
+// upstreamURL returns the base URL for the given provider.
+func (h *Handler) upstreamURL(provider string) (string, error) {
+	switch provider {
+	case providerLocal:
+		return h.cfg.LocalEndpoint, nil
+	case providerOpenRouter:
+		return openRouterBaseURL, nil
+	default:
+		return "", fmt.Errorf("unsupported inference provider: %s", provider)
+	}
+}
+
+// handleProxy reverse-proxies /v1/chat/completions and /v1/completions.
+func (h *Handler) handleProxy(w http.ResponseWriter, r *http.Request) {
+	infCfg, rec, err := h.getInferenceConfig(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if infCfg == nil {
+		http.Error(w, "inference not configured for this VM", http.StatusNotFound)
+		return
+	}
+
+	upstream, err := h.upstreamURL(infCfg.Provider)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	target, err := url.Parse(upstream)
+	if err != nil {
+		http.Error(w, "invalid upstream URL", http.StatusInternalServerError)
+		return
+	}
+
+	vmName := rec.VMID
+	log.Printf("inference: proxying %s %s for VM %s to %s", r.Method, r.URL.Path, vmName, upstream)
+
+	// Check if this is a streaming request by peeking at the body.
+	// We need to read the body to check, then pass it along.
+	isStreaming := false
+	if r.Body != nil {
+		bodyBytes, readErr := io.ReadAll(r.Body)
+		if readErr == nil {
+			// Check for "stream": true in the JSON body
+			var body map[string]interface{}
+			if json.Unmarshal(bodyBytes, &body) == nil {
+				if stream, ok := body["stream"]; ok {
+					if b, ok := stream.(bool); ok && b {
+						isStreaming = true
+					}
+				}
+			}
+			// Restore body for the proxy
+			r.Body = io.NopCloser(strings.NewReader(string(bodyBytes)))
+			r.ContentLength = int64(len(bodyBytes))
+		}
+	}
+
+	if isStreaming {
+		h.handleStreamingProxy(w, r, target, infCfg, vmName)
+		return
+	}
+
+	// Non-streaming: use standard httputil.ReverseProxy
+	proxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = target.Scheme
+			req.URL.Host = target.Host
+			req.Host = target.Host
+			// Path stays the same — /v1/chat/completions or /v1/completions
+			req.Header.Set("X-Forwarded-For", r.RemoteAddr)
+
+			if infCfg.Provider == providerOpenRouter && infCfg.APIKey != "" {
+				req.Header.Set("Authorization", "Bearer "+infCfg.APIKey)
+			}
+		},
+	}
+
+	proxy.ServeHTTP(w, r)
+}
+
+// handleStreamingProxy handles SSE streaming responses by flushing chunks immediately.
+func (h *Handler) handleStreamingProxy(w http.ResponseWriter, r *http.Request, target *url.URL, infCfg *registry.InferenceConfig, vmName string) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	// Build upstream request
+	upstreamURL := *target
+	upstreamURL.Path = r.URL.Path
+	upstreamURL.RawQuery = r.URL.RawQuery
+
+	proxyReq, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL.String(), r.Body)
+	if err != nil {
+		http.Error(w, "failed to create upstream request", http.StatusInternalServerError)
+		return
+	}
+
+	// Copy relevant headers
+	proxyReq.Header.Set("Content-Type", r.Header.Get("Content-Type"))
+	proxyReq.Header.Set("Accept", r.Header.Get("Accept"))
+	proxyReq.Header.Set("X-Forwarded-For", r.RemoteAddr)
+	proxyReq.Host = target.Host
+
+	if infCfg.Provider == providerOpenRouter && infCfg.APIKey != "" {
+		proxyReq.Header.Set("Authorization", "Bearer "+infCfg.APIKey)
+	}
+
+	resp, err := http.DefaultClient.Do(proxyReq)
+	if err != nil {
+		log.Printf("inference: upstream error for VM %s: %v", vmName, err)
+		http.Error(w, "upstream request failed", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Copy response headers
+	for k, vv := range resp.Header {
+		for _, v := range vv {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	flusher.Flush()
+
+	// Stream the response body, flushing after each chunk
+	buf := make([]byte, 4096)
+	for {
+		n, readErr := resp.Body.Read(buf)
+		if n > 0 {
+			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
+				log.Printf("inference: write error for VM %s: %v", vmName, writeErr)
+				return
+			}
+			flusher.Flush()
+		}
+		if readErr != nil {
+			if readErr != io.EOF {
+				log.Printf("inference: read error for VM %s: %v", vmName, readErr)
+			}
+			return
+		}
+	}
+}
+
+// handleModels returns the configured model for the calling VM in OpenAI-compatible format.
+func (h *Handler) handleModels(w http.ResponseWriter, r *http.Request) {
+	infCfg, _, err := h.getInferenceConfig(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if infCfg == nil {
+		http.Error(w, "inference not configured for this VM", http.StatusNotFound)
+		return
+	}
+
+	// Return OpenAI-compatible model list
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"object": "list",
+		"data": []map[string]interface{}{
+			{
+				"id":       infCfg.Model,
+				"object":   "model",
+				"owned_by": infCfg.Provider,
+			},
+		},
+	})
+}
+
+// handleConfig returns the raw inference configuration for the calling VM.
+func (h *Handler) handleConfig(w http.ResponseWriter, r *http.Request) {
+	infCfg, _, err := h.getInferenceConfig(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if infCfg == nil {
+		http.Error(w, "inference not configured for this VM", http.StatusNotFound)
+		return
+	}
+
+	// Return config without the API key
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"provider": infCfg.Provider,
+		"model":    infCfg.Model,
+	})
+}

--- a/node/vmid/internal/inference/proxy_test.go
+++ b/node/vmid/internal/inference/proxy_test.go
@@ -1,0 +1,341 @@
+package inference
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/AndrewBudd/boxcutter/node/vmid/internal/config"
+	"github.com/AndrewBudd/boxcutter/node/vmid/internal/middleware"
+	"github.com/AndrewBudd/boxcutter/node/vmid/internal/registry"
+)
+
+// setupTestHandler creates a Handler, Registry, and VMRecord for testing.
+func setupTestHandler(t *testing.T, infCfg *registry.InferenceConfig, upstreamURL string) (*Handler, *registry.Registry, *registry.VMRecord) {
+	t.Helper()
+
+	reg := registry.New()
+	rec := &registry.VMRecord{
+		VMID: "test-vm-1",
+		IP:   "10.0.0.2",
+		Mark: 100,
+		Mode: "normal",
+		AgentConfig: &registry.AgentConfig{
+			Team:  "test-team",
+			Agent: "test-agent",
+		},
+	}
+	if infCfg != nil {
+		rec.AgentConfig.Inference = infCfg
+	}
+	reg.Register(rec)
+
+	localEndpoint := "http://192.168.50.1:11434"
+	if upstreamURL != "" {
+		localEndpoint = upstreamURL
+	}
+
+	h := NewHandler(config.InferenceGlobalConfig{
+		LocalEndpoint: localEndpoint,
+	}, reg)
+
+	return h, reg, rec
+}
+
+// requestWithIdentity creates an HTTP request with the fwmark set in context.
+func requestWithIdentity(t *testing.T, mark int, method, path string, body io.Reader) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(method, path, body)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	ctx := middleware.WithMark(req.Context(), mark)
+	req = req.WithContext(ctx)
+	return req
+}
+
+// serveWithIdentity wraps a handler function with the identity middleware.
+func serveWithIdentity(reg *registry.Registry, handler http.HandlerFunc) http.Handler {
+	identityMW := middleware.Identity(reg)
+	return identityMW(http.HandlerFunc(handler))
+}
+
+func TestProxyLocalProvider(t *testing.T) {
+	// Set up a fake Ollama upstream
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("expected path /v1/chat/completions, got %s", r.URL.Path)
+		}
+		// Verify no Authorization header for local provider
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			t.Errorf("expected no Authorization header for local provider, got %s", auth)
+		}
+		if xff := r.Header.Get("X-Forwarded-For"); xff == "" {
+			t.Errorf("expected X-Forwarded-For header to be set")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":      "chatcmpl-123",
+			"object":  "chat.completion",
+			"choices": []map[string]interface{}{{"message": map[string]string{"content": "hello"}}},
+		})
+	}))
+	defer upstream.Close()
+
+	h, reg, _ := setupTestHandler(t, &registry.InferenceConfig{
+		Provider: "local",
+		Model:    "qwen3-coder:30b",
+	}, upstream.URL)
+
+	body := `{"model":"qwen3-coder:30b","messages":[{"role":"user","content":"hi"}]}`
+	req := requestWithIdentity(t, 100, "POST", "/v1/chat/completions", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	wrapped := serveWithIdentity(reg, h.handleProxy)
+	wrapped.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON response: %v", err)
+	}
+	if resp["id"] != "chatcmpl-123" {
+		t.Errorf("unexpected response id: %v", resp["id"])
+	}
+}
+
+func TestProxyOpenRouterInjectsAuth(t *testing.T) {
+	// Set up a fake upstream that records the Authorization header
+	var receivedAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprintf(w, "data: {\"id\":\"chatcmpl-789\"}\n\n")
+		fmt.Fprintf(w, "data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	reg := registry.New()
+	rec := &registry.VMRecord{
+		VMID: "test-vm-or",
+		IP:   "10.0.0.3",
+		Mark: 101,
+		Mode: "normal",
+		AgentConfig: &registry.AgentConfig{
+			Team:  "test-team",
+			Agent: "test-agent",
+			Inference: &registry.InferenceConfig{
+				Provider: "openrouter",
+				Model:    "deepseek/deepseek-coder",
+				APIKey:   "sk-or-test-key-123",
+			},
+		},
+	}
+	reg.Register(rec)
+
+	infCfg := rec.AgentConfig.Inference
+
+	// Test handleStreamingProxy directly with target pointing to our test server.
+	// This bypasses the URL resolution (which maps "openrouter" to the real URL)
+	// and lets us verify auth header injection.
+	target, _ := url.Parse(upstream.URL)
+
+	h := NewHandler(config.InferenceGlobalConfig{LocalEndpoint: "http://localhost:1"}, reg)
+
+	body := `{"model":"deepseek/deepseek-coder","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	h.handleStreamingProxy(rr, req, target, infCfg, "test-vm-or")
+
+	if receivedAuth != "Bearer sk-or-test-key-123" {
+		t.Errorf("expected Authorization header 'Bearer sk-or-test-key-123', got '%s'", receivedAuth)
+	}
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestSSEStreamingForwarded(t *testing.T) {
+	// Set up a fake upstream that returns SSE chunks
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("expected flusher support")
+		}
+
+		chunks := []string{
+			`data: {"id":"chatcmpl-1","choices":[{"delta":{"content":"Hello"}}]}`,
+			`data: {"id":"chatcmpl-1","choices":[{"delta":{"content":" world"}}]}`,
+			`data: [DONE]`,
+		}
+		for _, chunk := range chunks {
+			fmt.Fprintf(w, "%s\n\n", chunk)
+			flusher.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	h, reg, _ := setupTestHandler(t, &registry.InferenceConfig{
+		Provider: "local",
+		Model:    "qwen3-coder:30b",
+	}, upstream.URL)
+
+	body := `{"model":"qwen3-coder:30b","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	req := requestWithIdentity(t, 100, "POST", "/v1/chat/completions", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	wrapped := serveWithIdentity(reg, h.handleProxy)
+	wrapped.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	responseBody := rr.Body.String()
+	if !strings.Contains(responseBody, "Hello") {
+		t.Errorf("expected streamed response to contain 'Hello', got: %s", responseBody)
+	}
+	if !strings.Contains(responseBody, "[DONE]") {
+		t.Errorf("expected streamed response to contain '[DONE]', got: %s", responseBody)
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.Contains(ct, "text/event-stream") {
+		t.Errorf("expected Content-Type text/event-stream, got %s", ct)
+	}
+}
+
+func TestNoInferenceConfigReturns404(t *testing.T) {
+	// VM with no inference config
+	h, reg, _ := setupTestHandler(t, nil, "")
+
+	body := `{"model":"anything","messages":[{"role":"user","content":"hi"}]}`
+	req := requestWithIdentity(t, 100, "POST", "/v1/chat/completions", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	wrapped := serveWithIdentity(reg, h.handleProxy)
+	wrapped.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestAnthropicProviderReturns404(t *testing.T) {
+	// VM with anthropic provider should get 404 (Claude Code doesn't use proxy)
+	h, reg, _ := setupTestHandler(t, &registry.InferenceConfig{
+		Provider: "anthropic",
+		Model:    "claude-sonnet-4-20250514",
+	}, "")
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}`
+	req := requestWithIdentity(t, 100, "POST", "/v1/chat/completions", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	wrapped := serveWithIdentity(reg, h.handleProxy)
+	wrapped.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for anthropic provider, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestModelsEndpoint(t *testing.T) {
+	h, reg, _ := setupTestHandler(t, &registry.InferenceConfig{
+		Provider: "local",
+		Model:    "qwen3-coder:30b",
+	}, "")
+
+	req := requestWithIdentity(t, 100, "GET", "/v1/models", nil)
+	rr := httptest.NewRecorder()
+
+	wrapped := serveWithIdentity(reg, h.handleModels)
+	wrapped.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON response: %v", err)
+	}
+
+	if resp["object"] != "list" {
+		t.Errorf("expected object 'list', got %v", resp["object"])
+	}
+
+	data, ok := resp["data"].([]interface{})
+	if !ok || len(data) == 0 {
+		t.Fatal("expected non-empty data array")
+	}
+
+	model := data[0].(map[string]interface{})
+	if model["id"] != "qwen3-coder:30b" {
+		t.Errorf("expected model id 'qwen3-coder:30b', got %v", model["id"])
+	}
+	if model["owned_by"] != "local" {
+		t.Errorf("expected owned_by 'local', got %v", model["owned_by"])
+	}
+}
+
+func TestModelsEndpointNoConfig(t *testing.T) {
+	h, reg, _ := setupTestHandler(t, nil, "")
+
+	req := requestWithIdentity(t, 100, "GET", "/v1/models", nil)
+	rr := httptest.NewRecorder()
+
+	wrapped := serveWithIdentity(reg, h.handleModels)
+	wrapped.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestConfigEndpoint(t *testing.T) {
+	h, reg, _ := setupTestHandler(t, &registry.InferenceConfig{
+		Provider: "openrouter",
+		Model:    "deepseek/deepseek-coder",
+		APIKey:   "sk-secret",
+	}, "")
+
+	req := requestWithIdentity(t, 100, "GET", "/inference/config", nil)
+	rr := httptest.NewRecorder()
+
+	wrapped := serveWithIdentity(reg, h.handleConfig)
+	wrapped.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON response: %v", err)
+	}
+
+	if resp["provider"] != "openrouter" {
+		t.Errorf("expected provider 'openrouter', got %v", resp["provider"])
+	}
+	if resp["model"] != "deepseek/deepseek-coder" {
+		t.Errorf("expected model 'deepseek/deepseek-coder', got %v", resp["model"])
+	}
+	// API key should NOT be exposed
+	if _, ok := resp["api_key"]; ok {
+		t.Errorf("API key should not be exposed in config endpoint")
+	}
+}

--- a/node/vmid/internal/registry/registry.go
+++ b/node/vmid/internal/registry/registry.go
@@ -82,6 +82,14 @@ type VMConfigInfo struct {
 	DiskGB int    `json:"disk_gb,omitempty"`
 }
 
+// InferenceConfig describes the inference provider configuration for a VM.
+// This is passed as part of AgentConfig from the orchestrator.
+type InferenceConfig struct {
+	Provider string `json:"provider,omitempty"` // "local", "openrouter", or "anthropic"
+	Model    string `json:"model,omitempty"`    // e.g. "qwen3-coder:30b"
+	APIKey   string `json:"api_key,omitempty"`  // API key for cloud providers (e.g. OpenRouter)
+}
+
 // AgentConfig is the boot agent specification for a VM, derived from the
 // declarative team YAML. It tells the in-VM agent what persona to assume,
 // which repos to clone, what tapegun sequences to run, and access policy.
@@ -97,6 +105,7 @@ type AgentConfig struct {
 	VMConfig         *VMConfigInfo     `json:"vm_config,omitempty"`          // requested VM resource configuration
 	Labels           map[string]string `json:"labels,omitempty"`             // labels for the VM
 	TeamPersonaFiles []string          `json:"team_persona_files,omitempty"` // team-level persona file paths
+	Inference        *InferenceConfig  `json:"inference,omitempty"`          // inference provider config
 }
 
 // CheckpointData holds a session checkpoint for conversation persistence.


### PR DESCRIPTION
## Summary
- New `inference` package in vmid with reverse proxy for OpenAI-compatible API
- `POST /v1/chat/completions` and `POST /v1/completions` — proxied to Ollama (local) or OpenRouter (cloud)
- `GET /v1/models` — returns configured model in OpenAI-compatible format
- `GET /inference/config` — returns VM's inference config (without API key)
- SSE streaming support via `http.Flusher` for real-time token delivery
- Per-VM routing based on fwmark identity (same as existing metadata endpoints)
- Auth header injection for OpenRouter; no auth needed for local Ollama
- `InferenceConfig` added to registry's `AgentConfig` (provider, model, api_key)
- `InferenceGlobalConfig` in vmid config with `local_endpoint` (default: `http://192.168.50.1:11434`)

## Architecture
```
VM (OpenCode/aider) → 169.254.169.254/v1/chat/completions → vmid proxy
  → provider: "local"       → Ollama (host:11434)
  → provider: "openrouter"  → openrouter.ai/api (with Bearer auth)
  → provider: "anthropic"   → 404 (Claude Code uses Anthropic directly)
```

## Test plan
- [ ] 8 unit tests: local proxying, OpenRouter auth injection, SSE streaming, no-config 404, anthropic 404, /models, /inference/config
- [ ] Integration: configure Ollama on host, create VM with `inference.provider: local`, verify `/v1/chat/completions` returns model response
- [ ] Verify Claude Code VMs (no inference config) get 404 on `/v1/*` — no interference with existing flow

Part of #176 — pairs with the OpenCode golden image PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)