### PR TITLE
Add LiteLLM smart inference load balancer

### DIFF
--- a/host/ollama/.env.example
+++ b/host/ollama/.env.example
@@ -1,0 +1,6 @@
+# Copy to .env and fill in values.
+# On boxcutter hosts, the deploy script reads the OpenRouter key automatically
+# from ~/.boxcutter/secrets/openrouter-api-key.
+
+OPENROUTER_API_KEY=sk-or-v1-your-key-here
+LITELLM_MASTER_KEY=sk-litellm-master-change-me

--- a/host/ollama/deploy.sh
+++ b/host/ollama/deploy.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Deploy the Ollama + LiteLLM inference stack to /opt/ollama-docker-compose/.
+#
+# Reads the OpenRouter API key from ~/.boxcutter/secrets/openrouter-api-key.
+# Generates a random LiteLLM master key if one doesn't exist.
+#
+# Usage:
+#   bash host/ollama/deploy.sh                 # Deploy and start
+#   bash host/ollama/deploy.sh --pull-model     # Also pull qwen3-coder on both instances
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPLOY_DIR="/opt/ollama-docker-compose"
+SECRET_FILE="$HOME/.boxcutter/secrets/openrouter-api-key"
+PULL_MODEL=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --pull-model) PULL_MODEL=true ;;
+        *) echo "Unknown option: $arg"; exit 1 ;;
+    esac
+done
+
+echo "=== Deploying inference stack ==="
+
+# Create deploy directory
+sudo mkdir -p "$DEPLOY_DIR"
+
+# Copy config files
+sudo cp "$SCRIPT_DIR/docker-compose.yml" "$DEPLOY_DIR/docker-compose.yml"
+sudo cp "$SCRIPT_DIR/litellm-config.yaml" "$DEPLOY_DIR/litellm-config.yaml"
+echo "  copied docker-compose.yml and litellm-config.yaml"
+
+# Build .env from secrets
+ENV_FILE="$DEPLOY_DIR/.env"
+if [ -f "$SECRET_FILE" ]; then
+    OPENROUTER_KEY=$(cat "$SECRET_FILE" | tr -d '[:space:]')
+    echo "  read OpenRouter API key from $SECRET_FILE"
+else
+    echo "  WARNING: $SECRET_FILE not found, OpenRouter fallback will not work"
+    OPENROUTER_KEY="sk-or-v1-not-configured"
+fi
+
+# Generate or preserve LiteLLM master key
+if [ -f "$ENV_FILE" ]; then
+    EXISTING_MASTER=$(grep '^LITELLM_MASTER_KEY=' "$ENV_FILE" 2>/dev/null | cut -d= -f2-)
+fi
+if [ -n "$EXISTING_MASTER" ]; then
+    MASTER_KEY="$EXISTING_MASTER"
+    echo "  preserved existing LiteLLM master key"
+else
+    MASTER_KEY="sk-litellm-$(openssl rand -hex 16)"
+    echo "  generated new LiteLLM master key"
+fi
+
+sudo tee "$ENV_FILE" > /dev/null <<EOF
+OPENROUTER_API_KEY=${OPENROUTER_KEY}
+LITELLM_MASTER_KEY=${MASTER_KEY}
+EOF
+sudo chmod 600 "$ENV_FILE"
+echo "  wrote $ENV_FILE"
+
+# Start the stack
+echo ""
+echo "=== Starting services ==="
+cd "$DEPLOY_DIR"
+sudo docker compose up -d
+echo ""
+sudo docker compose ps
+
+# Pull model if requested
+if [ "$PULL_MODEL" = "true" ]; then
+    echo ""
+    echo "=== Pulling qwen3-coder on both Ollama instances ==="
+    echo "  ollama-a..."
+    sudo docker exec ollama-a ollama pull qwen3-coder
+    echo "  ollama-b..."
+    sudo docker exec ollama-b ollama pull qwen3-coder
+    echo "  model pull complete"
+fi
+
+echo ""
+echo "Done. LiteLLM proxy available at http://localhost:11430"
+echo "Health: curl http://localhost:11430/health"

--- a/host/ollama/docker-compose.yml
+++ b/host/ollama/docker-compose.yml
@@ -1,0 +1,92 @@
+# Ollama + LiteLLM inference stack.
+#
+# Two local Ollama instances (one per GPU) fronted by LiteLLM for
+# least-busy routing with OpenRouter overflow. See issue #180.
+#
+# Deployed to /opt/ollama-docker-compose/ on the host.
+#
+# Usage:
+#   cp .env.example .env   # then fill in secrets
+#   docker compose up -d
+#   docker exec ollama-a ollama pull qwen3-coder
+#   docker exec ollama-b ollama pull qwen3-coder
+
+services:
+  ollama-a:
+    image: ollama/ollama:latest
+    container_name: ollama-a
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-a-data:/root/.ollama
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=0
+      - OLLAMA_KEEP_ALIVE=-1
+      - OLLAMA_HOST=0.0.0.0:11434
+      - OLLAMA_MAX_LOADED_MODELS=1
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ['0']
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+
+  ollama-b:
+    image: ollama/ollama:latest
+    container_name: ollama-b
+    ports:
+      - "11435:11434"
+    volumes:
+      - ollama-b-data:/root/.ollama
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=2
+      - OLLAMA_KEEP_ALIVE=-1
+      - OLLAMA_HOST=0.0.0.0:11434
+      - OLLAMA_MAX_LOADED_MODELS=1
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ['2']
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+
+  litellm:
+    image: ghcr.io/berriai/litellm:main-latest
+    container_name: litellm
+    ports:
+      - "11430:4000"
+    volumes:
+      - ./litellm-config.yaml:/app/config.yaml:ro
+    environment:
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
+      - LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY:-sk-litellm-master}
+    command: ["--config", "/app/config.yaml", "--port", "4000", "--host", "0.0.0.0"]
+    depends_on:
+      ollama-a:
+        condition: service_healthy
+      ollama-b:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+
+volumes:
+  ollama-a-data:
+  ollama-b-data:

--- a/host/ollama/litellm-config.yaml
+++ b/host/ollama/litellm-config.yaml
@@ -1,0 +1,55 @@
+# LiteLLM proxy configuration — smart inference load balancer.
+#
+# Routes to local Ollama GPUs first (free), overflows to OpenRouter (paid)
+# when local capacity is exhausted. See issue #180 for design rationale.
+#
+# Deployed to /opt/ollama-docker-compose/litellm-config.yaml on the host.
+
+model_list:
+  # --- Local Ollama instances (free, preferred) ---
+  - model_name: "qwen3-coder"
+    litellm_params:
+      model: "ollama/qwen3-coder"
+      api_base: "http://ollama-a:11434"
+      timeout: 120
+      stream_timeout: 300
+    model_info:
+      id: "ollama-a"
+      input_cost_per_token: 0
+      output_cost_per_token: 0
+
+  - model_name: "qwen3-coder"
+    litellm_params:
+      model: "ollama/qwen3-coder"
+      api_base: "http://ollama-b:11434"
+      timeout: 120
+      stream_timeout: 300
+    model_info:
+      id: "ollama-b"
+      input_cost_per_token: 0
+      output_cost_per_token: 0
+
+  # --- OpenRouter cloud fallback (paid) ---
+  - model_name: "qwen3-coder-cloud"
+    litellm_params:
+      model: "openrouter/qwen/qwen3-coder"
+      api_key: "os.environ/OPENROUTER_API_KEY"
+      timeout: 120
+      stream_timeout: 300
+
+router_settings:
+  routing_strategy: "least-busy"
+  allowed_fails: 2
+  cooldown_time: 30
+  retry_after: 15
+  num_retries: 2
+
+  fallbacks:
+    - qwen3-coder: ["qwen3-coder-cloud"]
+
+general_settings:
+  master_key: "os.environ/LITELLM_MASTER_KEY"
+
+litellm_settings:
+  drop_params: true
+  set_verbose: false


### PR DESCRIPTION
## Summary

- Replace nginx round-robin LB with LiteLLM proxy for the Ollama inference stack
- LiteLLM uses `least-busy` routing to pick the Ollama instance with fewer in-flight requests
- When both local GPUs are busy/in cooldown, requests automatically overflow to OpenRouter (paid)
- Clients request `qwen3-coder` transparently — LiteLLM handles routing to local `ollama/qwen3-coder` or cloud `openrouter/qwen/qwen3-coder`

## Files

| File | Purpose |
|------|---------|
| `host/ollama/litellm-config.yaml` | LiteLLM routing config: 2 local Ollama backends + OpenRouter fallback |
| `host/ollama/docker-compose.yml` | ollama-a (GPU 0) + ollama-b (GPU 2) + litellm on port 11430 |
| `host/ollama/.env.example` | Template for secrets (OpenRouter key, LiteLLM master key) |
| `host/ollama/deploy.sh` | Deploy script: copies to `/opt/ollama-docker-compose/`, reads API key from `~/.boxcutter/secrets/openrouter-api-key`, pulls models |

## How it works

1. Client sends `POST /v1/chat/completions` with `model: qwen3-coder`
2. LiteLLM picks the Ollama instance with fewer in-flight requests (`least-busy`)
3. If both local instances fail/timeout → cooldown (30s) → overflow to OpenRouter
4. After cooldown expires, local instances re-enter rotation

## Test plan

- [ ] `docker compose config` validates cleanly (verified in CI env)
- [ ] Deploy to host with `bash host/ollama/deploy.sh --pull-model`
- [ ] `curl http://localhost:11430/health` returns healthy
- [ ] Send inference request, verify it routes to local Ollama
- [ ] Saturate both GPUs, verify overflow to OpenRouter
- [ ] Kill one Ollama container, verify cooldown + recovery

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)